### PR TITLE
watcher: change arbitrum RPC

### DIFF
--- a/watcher/src/consts.ts
+++ b/watcher/src/consts.ts
@@ -37,7 +37,7 @@ export const RPCS_BY_CHAIN: { [key in ChainName]?: string } = {
   klaytn: 'https://klaytn-mainnet-rpc.allthatnode.com:8551',
   celo: 'https://forno.celo.org',
   moonbeam: 'https://rpc.ankr.com/moonbeam',
-  arbitrum: 'https://rpc.ankr.com/arbitrum',
+  arbitrum: 'https://arb1.arbitrum.io/rpc',
   optimism: 'https://rpc.ankr.com/optimism',
   aptos: 'https://fullnode.mainnet.aptoslabs.com/',
   near: 'https://rpc.mainnet.near.org',

--- a/watcher/src/watchers/ArbitrumWatcher.ts
+++ b/watcher/src/watchers/ArbitrumWatcher.ts
@@ -20,7 +20,7 @@ export class ArbitrumWatcher extends EVMWatcher {
     this.latestL2Finalized = 0;
     this.l1L2Map = new Map<number, number>();
     this.lastEthTime = 0;
-    this.maximumBatchSize = 10;
+    this.maximumBatchSize = 25;
   }
 
   async getFinalizedBlockNumber(): Promise<number> {


### PR DESCRIPTION
Changed the RPC.  The arbitrum RPC seems to do a better job of keeping up.
Also, through testing it seems that we can send requests for 25 blocks.  At 25 blocks, we sometimes get a 429.  But backing off 1 second seems to clear it up.