### PR TITLE
Fix Sui transaction block link

### DIFF
--- a/dashboard/src/utils/explorer.ts
+++ b/dashboard/src/utils/explorer.ts
@@ -72,7 +72,7 @@ export const explorerBlock = (chainId: ChainId, block: string) =>
     : chainId === CHAIN_ID_INJECTIVE
     ? `https://explorer.injective.network/block/${block}`
     : chainId === CHAIN_ID_SUI
-    ? `https://suiexplorer.com/txblock/${block}`
+    ? `https://suiexplorer.com/checkpoint/${block}`
     : chainId === CHAIN_ID_BASE
     ? `https://basescan.org/block/${block}`
     : '';


### PR DESCRIPTION
Correct explorer URL appears to be `https://suiexplorer.com/checkpoint/${block}`.