### PR TITLE
watcher: change logging on near

### DIFF
--- a/watcher/scripts/backfillNear.ts
+++ b/watcher/scripts/backfillNear.ts
@@ -36,9 +36,6 @@ const BATCH_SIZE = 100;
     (await db.getLastBlockByChain(chain)) ?? INITIAL_DEPLOYMENT_BLOCK_BY_CHAIN[chain] ?? 0
   );
   const fromBlockTimestamp: number = await getTimestampByBlock(provider, fromBlock);
-  if (fromBlockTimestamp === 0) {
-    throw new Error(`Unable to fetch timestamp for fromBlock ${fromBlock}`);
-  }
   console.log(`Last block seen: ${fromBlock} at ${fromBlockTimestamp}`);
 
   // fetch all transactions for core bridge contract from explorer

--- a/watcher/scripts/backfillNear.ts
+++ b/watcher/scripts/backfillNear.ts
@@ -36,6 +36,9 @@ const BATCH_SIZE = 100;
     (await db.getLastBlockByChain(chain)) ?? INITIAL_DEPLOYMENT_BLOCK_BY_CHAIN[chain] ?? 0
   );
   const fromBlockTimestamp: number = await getTimestampByBlock(provider, fromBlock);
+  if (fromBlockTimestamp === 0) {
+    throw new Error(`Unable to fetch timestamp for fromBlock ${fromBlock}`);
+  }
   console.log(`Last block seen: ${fromBlock} at ${fromBlockTimestamp}`);
 
   // fetch all transactions for core bridge contract from explorer

--- a/watcher/src/utils/near.ts
+++ b/watcher/src/utils/near.ts
@@ -28,26 +28,23 @@ export async function getTimestampByBlock(
   provider: Provider,
   blockHeight: number
 ): Promise<number> {
-  const block: BlockResult = await fetchBlockByBlockId(provider, blockHeight);
+  const block: BlockResult | string = await fetchBlockByBlockId(provider, blockHeight);
+  if (typeof block === 'string') {
+    return 0;
+  }
   return block.header.timestamp;
 }
 
 export async function fetchBlockByBlockId(
   provider: Provider,
   blockHeight: BlockId
-): Promise<BlockResult> {
-  let success: boolean = false;
-  let block: BlockResult = {} as BlockResult;
-  while (!success) {
-    try {
-      block = await provider.block({ blockId: blockHeight });
-      success = true;
-    } catch (e) {
-      console.error('Error fetching block', e);
-      await sleep(5000);
-    }
+): Promise<BlockResult | string> {
+  try {
+    return await provider.block({ blockId: blockHeight });
+  } catch (e: any) {
+    console.error('fetchBlockById(): Error fetching block', e);
+    return e.toString();
   }
-  return block;
 }
 
 // This function will only return transactions in the time window.

--- a/watcher/src/utils/near.ts
+++ b/watcher/src/utils/near.ts
@@ -28,23 +28,15 @@ export async function getTimestampByBlock(
   provider: Provider,
   blockHeight: number
 ): Promise<number> {
-  const block: BlockResult | string = await fetchBlockByBlockId(provider, blockHeight);
-  if (typeof block === 'string') {
-    return 0;
-  }
+  const block: BlockResult = await fetchBlockByBlockId(provider, blockHeight);
   return block.header.timestamp;
 }
 
 export async function fetchBlockByBlockId(
   provider: Provider,
   blockHeight: BlockId
-): Promise<BlockResult | string> {
-  try {
-    return await provider.block({ blockId: blockHeight });
-  } catch (e: any) {
-    console.error('fetchBlockById(): Error fetching block', e);
-    return e.toString();
-  }
+): Promise<BlockResult> {
+  return await provider.block({ blockId: blockHeight });
 }
 
 // This function will only return transactions in the time window.


### PR DESCRIPTION
Near was having some errors that were only getting logged to console.error.  They need to be propagated up so that the error messages can get into Loki.  This PR makes those changes.