### PR TITLE
cloud_function: don't keep signed vaa

### DIFF
--- a/cloud_functions/src/alarmMissingVaas.ts
+++ b/cloud_functions/src/alarmMissingVaas.ts
@@ -230,8 +230,13 @@ async function getAndProcessReobsVAAs(): Promise<Map<string, ReobserveInfo>> {
         const data = doc.data();
         if (data) {
           const vaas: ReobserveInfo[] = data.VAAs;
-          vaas.forEach((vaa) => {
-            current.set(vaa.txhash, vaa);
+          vaas.forEach(async (vaa) => {
+            if (!(await isVAASigned(vaa.vaaKey))) {
+              console.log('keeping reobserved VAA in firestore', vaa.vaaKey);
+              current.set(vaa.txhash, vaa);
+            } else {
+              console.log('pruning reobserved VAA in firestore because it is signed. ', vaa.vaaKey);
+            }
           });
           console.log('number of reobserved VAAs', vaas.length);
         }

--- a/cloud_functions/src/utils.ts
+++ b/cloud_functions/src/utils.ts
@@ -93,7 +93,7 @@ export async function formatAndSendToSlack(msg: string): Promise<any> {
 }
 
 export async function isVAASigned(vaaKey: string): Promise<boolean> {
-  const url: string = WormholescanRPC + 'v1/signed_vaa/1/' + vaaKey;
+  const url: string = WormholescanRPC + 'v1/signed_vaa/' + vaaKey;
   try {
     const response = await axios.get(url);
     // curl -X 'GET' \
@@ -105,7 +105,7 @@ export async function isVAASigned(vaaKey: string): Promise<boolean> {
       return true;
     }
   } catch (e) {
-    console.error('Failed to query wormholescan with url', +url + "'", e);
+    console.error(`Failed to query wormholescan with url [${url}]`);
     return false;
   }
   return false;


### PR DESCRIPTION
If a VAA in the reobserve collection has been signed, then it no longer needs to be reobserved.