### PR TITLE
watcher: handle near missing blocks

### DIFF
--- a/watcher/src/utils/near.ts
+++ b/watcher/src/utils/near.ts
@@ -24,6 +24,7 @@ export const getNearProvider = async (rpc: string): Promise<Provider> => {
   return provider;
 };
 
+// This function can definitely throw.
 export async function getTimestampByBlock(
   provider: Provider,
   blockHeight: number
@@ -32,6 +33,7 @@ export async function getTimestampByBlock(
   return block.header.timestamp;
 }
 
+// This function can definitely throw.
 export async function fetchBlockByBlockId(
   provider: Provider,
   blockHeight: BlockId


### PR DESCRIPTION
Near can have gaps in block numbers.  So, if you are going to request a specific block number, be prepared to handle the case where it doesn't exist.