### PR TITLE
cloud-functions: bump go version

### DIFF
--- a/cloud-functions/deploy.sh
+++ b/cloud-functions/deploy.sh
@@ -6,6 +6,6 @@ if [ -z "$GCP_PROJECT" ]; then
     exit 1
 fi
 
-gcloud functions --project "$GCP_PROJECT" deploy guardian-heartbeats --region=europe-west3 --entry-point Heartbeats --memory=256MB --runtime go116 --trigger-http --allow-unauthenticated --update-env-vars GCP_PROJECT="$GCP_PROJECT"
-gcloud functions --project "$GCP_PROJECT" deploy governor-status --region=europe-west3 --entry-point GovernorStatus --memory=256MB --runtime go116 --trigger-http --allow-unauthenticated --update-env-vars GCP_PROJECT="$GCP_PROJECT"
-gcloud functions --project "$GCP_PROJECT" deploy governor-configs --region=europe-west3 --entry-point GovernorConfigs --memory=256MB --runtime go116 --trigger-http --allow-unauthenticated --update-env-vars GCP_PROJECT="$GCP_PROJECT"
+gcloud functions --project "$GCP_PROJECT" deploy guardian-heartbeats --region=europe-west3 --entry-point Heartbeats --memory=256MB --runtime go121 --trigger-http --allow-unauthenticated --update-env-vars GCP_PROJECT="$GCP_PROJECT"
+gcloud functions --project "$GCP_PROJECT" deploy governor-status --region=europe-west3 --entry-point GovernorStatus --memory=256MB --runtime go121 --trigger-http --allow-unauthenticated --update-env-vars GCP_PROJECT="$GCP_PROJECT"
+gcloud functions --project "$GCP_PROJECT" deploy governor-configs --region=europe-west3 --entry-point GovernorConfigs --memory=256MB --runtime go121 --trigger-http --allow-unauthenticated --update-env-vars GCP_PROJECT="$GCP_PROJECT"


### PR DESCRIPTION
I created and deployed parallel cloud functions using go 1.21.
https://console.cloud.google.com/functions/details/europe-west3/governor-configs-21?env=gen1&project=wormhole-message-db-mainnet&tab=metrics
https://console.cloud.google.com/functions/details/europe-west3/governor-status-21?env=gen1&project=wormhole-message-db-mainnet
https://console.cloud.google.com/functions/details/europe-west3/guardian-heartbeats-21?env=gen1&project=wormhole-message-db-mainnet