### PR TITLE
watcher: add testnet to logger product

### DIFF
--- a/watcher/src/utils/environment.ts
+++ b/watcher/src/utils/environment.ts
@@ -3,6 +3,7 @@ let loggingEnv: LoggingEnvironment | undefined = undefined;
 export type LoggingEnvironment = {
   logLevel: string;
   logDir?: string;
+  network?: string;
 };
 
 export const getEnvironment = () => {
@@ -12,6 +13,7 @@ export const getEnvironment = () => {
     loggingEnv = {
       logLevel: process.env.LOG_LEVEL || 'info',
       logDir: process.env.LOG_DIR,
+      network: process.env.NETWORK,
     };
     return loggingEnv;
   }

--- a/watcher/src/utils/logger.ts
+++ b/watcher/src/utils/logger.ts
@@ -45,7 +45,7 @@ export const getLogger = (source: string): WormholeLogger => {
 };
 
 const createBaseLogger = (): WormholeLogger => {
-  const { logLevel, logDir } = getEnvironment();
+  const { logLevel, logDir, network } = getEnvironment();
   const logPath = !!logDir ? `${logDir}/watcher.${new Date().toISOString()}.log` : null;
   let transport: winston.transport[] = [
     logPath
@@ -60,7 +60,7 @@ const createBaseLogger = (): WormholeLogger => {
     const GRAFANA_HOST = assertEnvironmentVariable('GRAFANA_HOST');
     const GRAFANA_USERID = assertEnvironmentVariable('GRAFANA_USERID');
     const GRAFANA_PASSWORD = assertEnvironmentVariable('GRAFANA_PASSWORD');
-    const MY_APP_NAME = 'wormhole-dashboard';
+    const MY_APP_NAME = network === '' ? 'wormhole-dashboard' : `wormhole-dashboard-${network}`;
     const GRAFANA_BASICAUTH = GRAFANA_USERID + ':' + GRAFANA_PASSWORD;
     transport.push(
       new LokiTransport({


### PR DESCRIPTION
This PR allows the splitting of the logs going to Loki into mainnet and testnet versions for easier viewing.