### PR TITLE
Add @certusone/wormhole-sdk dependency to cloud_functions

### DIFF
--- a/cloud_functions/package.json
+++ b/cloud_functions/package.json
@@ -12,6 +12,7 @@
     "gcp-build": "npm i ./dist/src/wormhole-foundation-wormhole-monitor-common-0.0.1.tgz ./dist/src/wormhole-foundation-wormhole-monitor-database-0.0.1.tgz"
   },
   "dependencies": {
+    "@certusone/wormhole-sdk": "^0.10.7",
     "@cosmjs/cosmwasm-stargate": "^0.31.1",
     "@google-cloud/bigtable": "^4.1.0",
     "@google-cloud/functions-framework": "^3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "name": "@wormhole-foundation/wormhole-monitor-cloud-functions",
       "version": "0.0.1",
       "dependencies": {
+        "@certusone/wormhole-sdk": "^0.10.7",
         "@cosmjs/cosmwasm-stargate": "^0.31.1",
         "@google-cloud/bigtable": "^4.1.0",
         "@google-cloud/functions-framework": "^3.1.3",
@@ -342,7 +343,6 @@
       "name": "@wormhole-foundation/wormhole-monitor-database",
       "version": "0.0.1",
       "dependencies": {
-        "@certusone/wormhole-sdk": "^0.10.7",
         "@google-cloud/bigtable": "^4.4.0",
         "@google-cloud/pubsub": "^3.4.1",
         "@injectivelabs/networks": "^1.0.73",
@@ -33159,6 +33159,7 @@
     "@wormhole-foundation/wormhole-monitor-cloud-functions": {
       "version": "file:cloud_functions",
       "requires": {
+        "@certusone/wormhole-sdk": "^0.10.7",
         "@cosmjs/cosmwasm-stargate": "^0.31.1",
         "@google-cloud/bigtable": "^4.1.0",
         "@google-cloud/functions-framework": "^3.1.3",
@@ -33378,7 +33379,6 @@
     "@wormhole-foundation/wormhole-monitor-database": {
       "version": "file:database",
       "requires": {
-        "@certusone/wormhole-sdk": "^0.10.7",
         "@google-cloud/bigtable": "^4.4.0",
         "@google-cloud/pubsub": "^3.4.1",
         "@injectivelabs/networks": "^1.0.73",


### PR DESCRIPTION
Was having an error deploying without this. We should add it back for now.