### PR TITLE
watcher: terra2 to use explorer watcher

### DIFF
--- a/watcher/src/watchers/utils.ts
+++ b/watcher/src/watchers/utils.ts
@@ -49,9 +49,9 @@ export function makeFinalizedWatcher(chainName: ChainName): Watcher {
     return new InjectiveExplorerWatcher();
   } else if (chainName === 'sei') {
     return new SeiExplorerWatcher();
-  } else if (chainName === 'terra') {
-    return new TerraExplorerWatcher('terra');
-  } else if (chainName === 'terra2' || chainName === 'xpla') {
+  } else if (chainName === 'terra' || chainName === 'terra2') {
+    return new TerraExplorerWatcher(chainName);
+  } else if (chainName === 'xpla') {
     return new CosmwasmWatcher(chainName);
   } else if (chainName === 'sui') {
     return new SuiWatcher();


### PR DESCRIPTION
The terra lcd watcher can't keep up any longer.  Need to switch to explorer watcher.