### PR TITLE
dashboard: change explorer rpc

### DIFF
--- a/common/src/explorer.ts
+++ b/common/src/explorer.ts
@@ -136,10 +136,7 @@ export const explorerTx = (chainId: ChainId, tx: string) =>
     ? `https://bigdipper.live/wormhole/transactions/${tx}`
     : '';
 
-export const explorerVaa = (key: string) =>
-  `https://wormhole.com/explorer/?emitterChain=${key.split('/')[0]}&emitterAddress=${
-    key.split('/')[1]
-  }&sequence=${key.split('/')[2]}`;
+export const explorerVaa = (key: string) => `https://wormholescan.io/#/tx/${key}`;
 
 export const getExplorerTxHash = (chain: ChainId, txHash: string) => {
   let explorerTxHash = '';


### PR DESCRIPTION
I did actually run the dashboard to make sure the explorer link showed up correctly and went to the correct location.