### PR TITLE
historical_uptime: push precomputed chain height differences

### DIFF
--- a/fly/common/types.go
+++ b/fly/common/types.go
@@ -1,0 +1,7 @@
+package common
+
+type GuardianHeight map[string]uint64 // map of guardian addr to chain height
+
+type GuardianChainHeights map[uint32]GuardianHeight // map of chainIds to guardian heights
+
+type ChainHeights map[uint32]uint64 // map of chainIds to heights

--- a/fly/pkg/historical_uptime/helpers.go
+++ b/fly/pkg/historical_uptime/helpers.go
@@ -69,3 +69,45 @@ func UpdateMetrics(guardianMissedObservations *prometheus.CounterVec, guardianMi
 		}
 	}
 }
+
+func computeMaxChainHeights(guardianChainHeights common.GuardianChainHeights) common.ChainHeights {
+	maxChainHeights := make(common.ChainHeights)
+
+	for chainId, guardianHeights  := range guardianChainHeights {
+		highest := uint64(0)
+
+		for _, guardianHeight := range guardianHeights {
+			if highest < guardianHeight {
+				highest = guardianHeight
+			}
+		}
+
+		maxChainHeights[chainId] = highest
+	}
+
+	return maxChainHeights
+}
+
+func computeGuardianChainHeightDifferences(guardianChainHeights common.GuardianChainHeights, maxChainHeights common.ChainHeights) common.GuardianChainHeights {
+	heightDifferences := make(common.GuardianChainHeights)
+
+	for chainId, guardianHeights := range guardianChainHeights {
+		for guardian, height := range guardianHeights {
+			if heightDifferences[chainId] == nil {
+				heightDifferences[chainId] = make(common.GuardianHeight)
+			}
+
+			// maxChainHeights[chain] always guaranteed to be at least height since it's computed in `computeMaxChainHeights`
+			heightDifferences[chainId][guardian] = maxChainHeights[chainId] - height
+		}
+	}
+
+	return heightDifferences
+}
+
+func GetGuardianHeightDifferencesByChain(guardianChainHeights common.GuardianChainHeights) common.GuardianChainHeights {
+	maxChainHeights := computeMaxChainHeights(guardianChainHeights)
+	return computeGuardianChainHeightDifferences(guardianChainHeights, maxChainHeights)
+}
+
+


### PR DESCRIPTION
Precompute chain height differences before pushing to prometheus. This makes it easier to group and reduce the metrics on Grafana side.