### PR TITLE
ntt_solana_watcher: fix watcher not invoking getNttMessagesForBlocks

### DIFF
--- a/common/src/consts.ts
+++ b/common/src/consts.ts
@@ -105,7 +105,7 @@ export const INITIAL_NTT_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN: {
 } = {
   ['mainnet']: {},
   ['testnet']: {
-    solana: '284788472',
+    solana: '285100152',
     sepolia: '5472203',
     arbitrum_sepolia: '22501243',
     base_sepolia: '7249669',

--- a/common/src/solana.ts
+++ b/common/src/solana.ts
@@ -112,5 +112,5 @@ export const findFromSignatureAndToSignature = async (
   const toSignature =
     fromBlock.transactions[fromBlock.transactions.length - 1].transaction.signatures[0];
 
-  return { fromSignature, toSignature };
+  return { fromSignature, toSignature, toBlock };
 };

--- a/watcher/src/watchers/NTTSolanaWatcher.ts
+++ b/watcher/src/watchers/NTTSolanaWatcher.ts
@@ -254,7 +254,7 @@ export class NTTSolanaWatcher extends SolanaWatcher {
       transceiverMessageAccountKey
     );
     const digest = getNttManagerMessageDigest(
-      coalesceChainId(this.chain),
+      coalesceChainId(transceiverMessage.ntt_managerPayload.payload.recipientChain as ChainId),
       transceiverMessage.ntt_managerPayload
     );
 
@@ -382,7 +382,7 @@ export class NTTSolanaWatcher extends SolanaWatcher {
         parsedVaa.sequence
       }`,
       digest: getNttManagerMessageDigest(
-        coalesceChainId(this.chain),
+        coalesceChainId(parsedVaa.emitterChain as ChainId),
         transceiverMessage.ntt_managerPayload
       ),
       transferTime: '',
@@ -571,7 +571,10 @@ export class NTTSolanaWatcher extends SolanaWatcher {
       currSignature = signatures.at(-1)?.signature;
     }
 
-    const lastBlockKey = makeBlockKey(toSlot.toString(), new Date(toBlock.blockTime! * 1000).toISOString());
+    const lastBlockKey = makeBlockKey(
+      toSlot.toString(),
+      new Date(toBlock.blockTime! * 1000).toISOString()
+    );
     return lastBlockKey;
   }
 

--- a/watcher/src/watchers/NTTSolanaWatcher.ts
+++ b/watcher/src/watchers/NTTSolanaWatcher.ts
@@ -508,7 +508,7 @@ export class NTTSolanaWatcher extends SolanaWatcher {
 
   async getNttMessagesForBlocks(fromSlot: number, toSlot: number): Promise<string> {
     this.logger.info(`fetching info for blocks ${fromSlot} to ${toSlot}`);
-    const { fromSignature, toSignature } = await findFromSignatureAndToSignature(
+    const { fromSignature, toSignature, toBlock } = await findFromSignatureAndToSignature(
       this.getConnection(),
       fromSlot,
       toSlot
@@ -571,7 +571,7 @@ export class NTTSolanaWatcher extends SolanaWatcher {
       currSignature = signatures.at(-1)?.signature;
     }
 
-    const lastBlockKey = makeBlockKey(toSlot.toString(), new Date(toSlot! * 1000).toISOString());
+    const lastBlockKey = makeBlockKey(toSlot.toString(), new Date(toBlock.blockTime! * 1000).toISOString());
     return lastBlockKey;
   }
 

--- a/watcher/src/watchers/NTTSolanaWatcher.ts
+++ b/watcher/src/watchers/NTTSolanaWatcher.ts
@@ -80,7 +80,7 @@ export class NTTSolanaWatcher extends SolanaWatcher {
   lifecycleMap: Map<string, LifeCycle>; // digest -> lifecycle
 
   constructor(network: Environment) {
-    super(network);
+    super(network, true);
     this.rpc = RPCS_BY_CHAIN[this.network].solana!;
     this.programId = NTT_CONTRACT[this.network].solana!;
     this.lifecycleMap = new Map<string, LifeCycle>();
@@ -526,6 +526,10 @@ export class NTTSolanaWatcher extends SolanaWatcher {
         });
 
       this.logger.info(`processing ${signatures.length} transactions`);
+
+      if (signatures.length === 0) {
+        break;
+      }
 
       const results = await this.getConnection().getTransactions(
         signatures.map((s) => s.signature),

--- a/watcher/src/watchers/SolanaWatcher.ts
+++ b/watcher/src/watchers/SolanaWatcher.ts
@@ -38,8 +38,8 @@ export class SolanaWatcher extends Watcher {
 
   connection: Connection | undefined;
 
-  constructor(network: Environment) {
-    super(network, 'solana');
+  constructor(network: Environment, isNTT: boolean = false) {
+    super(network, 'solana', isNTT);
     this.rpc = RPCS_BY_CHAIN[this.network].solana!;
     this.programId = WORMHOLE_PROGRAM_ID;
   }

--- a/watcher/src/watchers/Watcher.ts
+++ b/watcher/src/watchers/Watcher.ts
@@ -63,6 +63,7 @@ export class Watcher {
       this.chain,
       this.isNTT
     );
+
     let retry = 0;
     while (true) {
       try {


### PR DESCRIPTION
set `this.NTT` to `true` to enable `getNttMessagesForBlocks` for solana ntt