### PR TITLE
Config page

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -19,6 +19,7 @@
     "@types/react-dom": "^18.0.6",
     "@wormhole-foundation/sdk-icons": "^0.6.6-beta.1",
     "axios": "^0.27.2",
+    "buffer": "^6.0.3",
     "numeral": "^2.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/dashboard/src/components/Contracts.tsx
+++ b/dashboard/src/components/Contracts.tsx
@@ -1,0 +1,104 @@
+import {
+  Card,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import {
+  Chain,
+  chainToChainId,
+  chainToPlatform,
+  chains,
+  contracts,
+  rpc,
+} from '@wormhole-foundation/sdk-base';
+import { useEffect, useState } from 'react';
+import { useNetworkContext } from '../contexts/NetworkContext';
+import CollapsibleSection from './CollapsibleSection';
+import { callContractMethod, getMethodId } from '@wormhole-foundation/wormhole-monitor-common';
+
+const coreBridgeChains = chains.filter((chain) => contracts.coreBridge.get('Mainnet', chain));
+
+function useGetGuardianSet(chain: Chain, address: string | undefined) {
+  const network = useNetworkContext();
+  const [guardianSet, setGuardianSet] = useState<[bigint | null, string | null]>([null, null]);
+  useEffect(() => {
+    setGuardianSet([null, null]);
+    if (!address) return;
+    let cancelled = false;
+    if (chainToPlatform(chain) === 'Evm') {
+      const rpcUrl = rpc.rpcAddress(network.currentNetwork.env, chain);
+      if (!rpcUrl) return;
+      (async () => {
+        try {
+          const gsi = await callContractMethod(
+            rpcUrl,
+            address,
+            getMethodId('getCurrentGuardianSetIndex()')
+          );
+          if (cancelled) return;
+          const gs = await callContractMethod(
+            rpcUrl,
+            address,
+            getMethodId('getGuardianSet(uint32)'),
+            gsi.substring(2) // strip 0x
+          );
+          if (cancelled) return;
+          setGuardianSet([BigInt(gsi), gs]);
+        } catch (e) {}
+      })();
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [network.currentNetwork.env, chain, address]);
+  return guardianSet;
+}
+
+function CoreBridgeInfo({ chain, address }: { chain: Chain; address: string | undefined }) {
+  const guardianSet = useGetGuardianSet(chain, address);
+  const guardianSetIndex = guardianSet[0]?.toString();
+  if (!address) return null;
+  return (
+    <TableRow>
+      <TableCell>{chain}</TableCell>
+      <TableCell>{chainToChainId(chain)}</TableCell>
+      <TableCell>{address}</TableCell>
+      <TableCell>{guardianSetIndex}</TableCell>
+    </TableRow>
+  );
+}
+
+function Contracts() {
+  return (
+    <CollapsibleSection header="Core">
+      <Card>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Chain Name</TableCell>
+                <TableCell>Chain ID</TableCell>
+                <TableCell>Address</TableCell>
+                <TableCell>Guardian Set Index</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {coreBridgeChains.map((chain: Chain) => (
+                <CoreBridgeInfo
+                  key={chain}
+                  chain={chain}
+                  address={contracts.coreBridge.get('Mainnet', chain)}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Card>
+    </CollapsibleSection>
+  );
+}
+export default Contracts;

--- a/dashboard/src/components/Contracts.tsx
+++ b/dashboard/src/components/Contracts.tsx
@@ -36,7 +36,13 @@ function useGetGuardianSet(chain: Chain, address: string | undefined) {
     setGuardianSet([null, null]);
     if (!address) return;
     const rpcUrl =
-      chain === 'Wormchain' ? WORMCHAIN_URL : rpc.rpcAddress(network.currentNetwork.env, chain);
+      chain === 'Klaytn'
+        ? 'https://klaytn-mainnet-rpc.allthatnode.com:8551'
+        : chain === 'Near'
+        ? 'https://rpc.mainnet.near.org'
+        : chain === 'Wormchain'
+        ? WORMCHAIN_URL
+        : rpc.rpcAddress(network.currentNetwork.env, chain);
     if (!rpcUrl) return;
     let cancelled = false;
     const platform = chainToPlatform(chain);
@@ -112,6 +118,83 @@ function useGetGuardianSet(chain: Chain, address: string | undefined) {
           );
           if (cancelled) return;
           setGuardianSet([BigInt(currentGuardianSetIndexState.value.uint), null]);
+        } catch (e) {}
+      })();
+    } else if (platform === 'Near') {
+      // https://docs.near.org/api/rpc/contracts#view-contract-state
+      (async () => {
+        try {
+          const response = await axios.post(rpcUrl, {
+            jsonrpc: '2.0',
+            id: 'dontcare',
+            method: 'query',
+            params: {
+              request_type: 'view_state',
+              finality: 'final',
+              account_id: address,
+              prefix_base64: 'U1RBVEU=', // STATE
+            },
+          });
+          const state = Buffer.from(
+            response.data.result.values.find(
+              (s: any) => Buffer.from(s.key, 'base64').toString('ascii') === 'STATE'
+            ).value,
+            'base64'
+          ).toString('hex');
+          // a tiny hack - instead of parsing the whole state, just find the expiry, which comes before the guardian set index
+          // https://github.com/wormhole-foundation/wormhole/blob/main/near/contracts/wormhole/src/lib.rs#L109
+          const expiry = `00004f91944e0000`; // = 24 * 60 * 60 * 1_000_000_000, // 24 hours in nanoseconds
+          const expiryIndex = state.indexOf(expiry);
+          const gsiIndex = expiryIndex + 16; // u64 len in hex
+          const gsi = BigInt(
+            `0x${state
+              .substring(gsiIndex, gsiIndex + 8)
+              .match(/../g)
+              ?.reverse()
+              .join('')}`
+          );
+          if (cancelled) return;
+          setGuardianSet([gsi, null]);
+        } catch (e) {}
+      })();
+    } else if (platform === 'Aptos') {
+      // https://aptos.dev/nodes/aptos-api-spec/#/
+      (async () => {
+        try {
+          const response = await axios.get(
+            `${rpcUrl}/accounts/${address}/resource/${address}::state::WormholeState`
+          );
+          const gsi = BigInt(response.data.data.guardian_set_index.number);
+          // const gsHandle = response.data.data.guardian_sets
+          if (cancelled) return;
+          setGuardianSet([gsi, null]);
+        } catch (e) {}
+      })();
+    } else if (platform === 'Sui') {
+      // https://docs.sui.io/sui-api-ref#sui_getobject
+      (async () => {
+        try {
+          const response = await axios.post(rpcUrl, {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'sui_getObject',
+            params: [
+              address,
+              {
+                showType: false,
+                showOwner: false,
+                showPreviousTransaction: false,
+                showDisplay: false,
+                showContent: true,
+                showBcs: false,
+                showStorageRebate: false,
+              },
+            ],
+          });
+          const gsi = BigInt(response.data.result.data.content.fields.guardian_set_index);
+          // const gsTable = response.data.result.data.content.fields.guardian_sets);
+          if (cancelled) return;
+          setGuardianSet([gsi, null]);
         } catch (e) {}
       })();
     }

--- a/dashboard/src/components/Main.tsx
+++ b/dashboard/src/components/Main.tsx
@@ -1,4 +1,9 @@
-import { GitHub } from '@mui/icons-material';
+import {
+  AnalyticsOutlined,
+  GitHub,
+  ReceiptLongOutlined,
+  SyncAltOutlined,
+} from '@mui/icons-material';
 import { AppBar, Box, Button, Hidden, IconButton, Toolbar, Typography } from '@mui/material';
 import { NavLink, Route, Switch, useLocation } from 'react-router-dom';
 import useChainHeartbeats from '../hooks/useChainHeartbeats';
@@ -6,6 +11,7 @@ import useHeartbeats from '../hooks/useHeartbeats';
 import useLatestRelease from '../hooks/useLatestRelease';
 import WormholeStatsIcon from '../icons/WormholeStatsIcon';
 import Alerts from './Alerts';
+import Contracts from './Contracts';
 import Home from './Home';
 import Metrics from './Metrics';
 import NTTMetrics from './NTTMetrics';
@@ -33,10 +39,31 @@ function NavLinks() {
         <Box display="flex" alignItems="center">
           <WormholeStatsIcon />
         </Box>
-        <Hidden smDown>
+        <Hidden mdDown>
           <Typography variant="h6" sx={{ pl: 0.75 }}>
             Dashboard
           </Typography>
+        </Hidden>
+      </NavLink>
+      <NavLink
+        to={`/contracts${search}`}
+        exact
+        component={NavButton}
+        color="inherit"
+        activeStyle={{ borderBottom: '2px solid', paddingBottom: 4 }}
+        style={{
+          paddingRight: 8,
+          marginLeft: 8,
+          textTransform: 'none',
+          borderRadius: 0,
+          minWidth: 0,
+        }}
+      >
+        <Hidden mdUp>
+          <ReceiptLongOutlined />
+        </Hidden>
+        <Hidden mdDown>
+          <Typography variant="h6">Contracts</Typography>
         </Hidden>
       </NavLink>
       <NavLink
@@ -45,9 +72,20 @@ function NavLinks() {
         component={NavButton}
         color="inherit"
         activeStyle={{ borderBottom: '2px solid', paddingBottom: 4 }}
-        style={{ paddingRight: 8, marginLeft: 8, textTransform: 'none', borderRadius: 0 }}
+        style={{
+          paddingRight: 8,
+          marginLeft: 8,
+          textTransform: 'none',
+          borderRadius: 0,
+          minWidth: 0,
+        }}
       >
-        <Typography variant="h6">Metrics</Typography>
+        <Hidden mdUp>
+          <AnalyticsOutlined />
+        </Hidden>
+        <Hidden mdDown>
+          <Typography variant="h6">Metrics</Typography>
+        </Hidden>
       </NavLink>
       <NavLink
         to={`/ntt-metrics${search}`}
@@ -55,9 +93,20 @@ function NavLinks() {
         component={NavButton}
         color="inherit"
         activeStyle={{ borderBottom: '2px solid', paddingBottom: 4 }}
-        style={{ paddingRight: 8, marginLeft: 8, textTransform: 'none', borderRadius: 0 }}
+        style={{
+          paddingRight: 8,
+          marginLeft: 8,
+          textTransform: 'none',
+          borderRadius: 0,
+          minWidth: 0,
+        }}
       >
-        <Typography variant="h6">NTT</Typography>
+        <Hidden mdUp>
+          <SyncAltOutlined />
+        </Hidden>
+        <Hidden mdDown>
+          <Typography variant="h6">NTT</Typography>
+        </Hidden>
       </NavLink>
     </>
   );
@@ -70,7 +119,7 @@ function Main() {
   return (
     <>
       <AppBar position="static">
-        <Toolbar variant="dense">
+        <Toolbar variant="dense" sx={{ minHeight: 40 }}>
           <NavLinks />
           <Box flexGrow={1} />
           <Hidden smDown>
@@ -99,6 +148,9 @@ function Main() {
         </Route>
         <Route path="/metrics">
           <Metrics />
+        </Route>
+        <Route path="/contracts">
+          <Contracts />
         </Route>
         <Route path="/">
           <Home

--- a/dashboard/src/index.tsx
+++ b/dashboard/src/index.tsx
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+globalThis.Buffer = Buffer;
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';

--- a/package-lock.json
+++ b/package-lock.json
@@ -441,6 +441,7 @@
         "@types/react-dom": "^18.0.6",
         "@wormhole-foundation/sdk-icons": "^0.6.6-beta.1",
         "axios": "^0.27.2",
+        "buffer": "^6.0.3",
         "numeral": "^2.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -8962,6 +8963,8 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -8976,7 +8979,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -24181,6 +24183,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "@wormhole-foundation/sdk-icons": "^0.6.6-beta.1",
         "axios": "^0.27.2",
+        "buffer": "^6.0.3",
         "numeral": "^2.0.6",
         "prettier": "^2.3.2",
         "react": "^18.2.0",
@@ -26217,6 +26220,8 @@
     },
     "buffer": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"


### PR DESCRIPTION
Adds a new page to display core contract info starting with the current guardian set index. This can be useful for contributors and integrators to track during a guardian set upgrade. Note that currently Solana and Pythnet are not supported since the dashboard does not have an allocated Solana or Pythnet RPC to use (every other chain has public endpoint usable from a web page). A future PR may move this functionality into a cloud function so that this info can be provided and cached.