### PR TITLE
watcher: de-dup sui digest results

### DIFF
--- a/watcher/src/watchers/SuiWatcher.ts
+++ b/watcher/src/watchers/SuiWatcher.ts
@@ -89,9 +89,11 @@ export class SuiWatcher extends Watcher {
         : null;
       cursor = response.nextCursor;
       hasNextPage = response.hasNextPage;
+      const digestArrayWithDups = response.data.map((e) => e.id.txDigest);
+      const digestArray = Array.from(new Set(digestArrayWithDups));
       const txBlocks = await this.client.requestWithType(
         'sui_multiGetTransactionBlocks',
-        { digests: response.data.map((e) => e.id.txDigest) },
+        { digests: digestArray },
         array(SuiTransactionBlockResponse)
       );
       const checkpointByTxDigest = txBlocks.reduce<Record<string, string | undefined>>(


### PR DESCRIPTION
Apparently, suix_queryEvents is returning duplicate digests where it hadn't before.  If there are duplicate digests in the sui_multiGetTransactionBlocks call, it throws with a duplicate input error.