### PR TITLE
watcher: change Solana maximumBatchSize

### DIFF
--- a/watcher/src/watchers/SolanaWatcher.ts
+++ b/watcher/src/watchers/SolanaWatcher.ts
@@ -33,7 +33,7 @@ export class SolanaWatcher extends Watcher {
   // transactions returned. Since we don't know the number of transactions in advance, we use
   // a block range of 100K slots. Technically, batch size can be arbitrarily large since pagination
   // of the WH transactions within that range is handled internally below.
-  maximumBatchSize = 100_000;
+  maximumBatchSize = 1_000;
 
   connection: Connection | undefined;
 


### PR DESCRIPTION
The maximumBatchSize needs to be changed down to 1000 because the watcher was receiving ```413 Payload Too Large```