### PR TITLE
cloud_functions: fix rpc-websockets

### DIFF
--- a/cloud_functions/package.json
+++ b/cloud_functions/package.json
@@ -30,7 +30,8 @@
     "knex": "^2.4.2",
     "path-to-regexp": "^6.2.1",
     "pg": "^8.10.0",
-    "prom-client": "^15.1.1"
+    "prom-client": "^15.1.1",
+    "rpc-websockets": "7.11.0"
   },
   "devDependencies": {
     "typescript": "^5.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,8 @@
         "knex": "^2.4.2",
         "path-to-regexp": "^6.2.1",
         "pg": "^8.10.0",
-        "prom-client": "^15.1.1"
+        "prom-client": "^15.1.1",
+        "rpc-websockets": "7.11.0"
       },
       "devDependencies": {
         "typescript": "^5.2.2"
@@ -23191,6 +23192,8 @@
       "version": "7.11.0",
       "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.0.tgz",
       "integrity": "sha512-IkLYjayPv6Io8C/TdCL5gwgzd1hFz2vmBZrjMw/SPEXo51ETOhnzgS4Qy5GWi2JQN7HKHa66J3+2mv0fgNh/7w==",
+      "deprecated": "deprecate 7.11.0",
+      "license": "LGPL-3.0-only",
       "dependencies": {
         "eventemitter3": "^4.0.7",
         "uuid": "^8.3.2",


### PR DESCRIPTION
The result of `npm i --save-exact rpc-websockets@7.11.0 -w cloud_functions`, this fixes an issue where a breaking patch release of `rpc-websockets` kills the cloud_functions deploy which don't adhere to the package lock. Ideally that could be fixed, but this PR just aims to get things working as they were.