### PR TITLE
ft_watcher: parse auction history if auction is closed

### DIFF
--- a/database/fast-transfer-schema.sql
+++ b/database/fast-transfer-schema.sql
@@ -3,6 +3,7 @@ DROP TABLE IF EXISTS fast_transfer_auctions;
 DROP TABLE IF EXISTS fast_transfer_executions;
 DROP TABLE IF EXISTS fast_transfer_settlements;
 DROP TABLE IF EXISTS auction_logs;
+DROP TABLE IF EXISTS auction_history_mapping;
 
 DROP TYPE IF EXISTS FastTransferStatus;
 DROP TYPE IF EXISTS FastTransferProtocol;
@@ -79,4 +80,12 @@ CREATE TABLE auction_logs (
   security_deposit BIGINT NOT NULL,
   offer_price BIGINT NOT NULL,
   timestamp TIMESTAMP NOT NULL
+);
+
+-- Auction History Mapping tracks which auction history pubkey is associated with
+-- which auction pubkey. This is to prevent having to search for the auction in auction
+-- history on chain which takes O(n) time, where n is the number of auction histories.
+CREATE TABLE auction_history_mapping (
+  auction_pubkey VARCHAR(255) PRIMARY KEY,
+  index INT NOT NULL
 );

--- a/watcher/src/fastTransfer/types.ts
+++ b/watcher/src/fastTransfer/types.ts
@@ -1,3 +1,4 @@
+import { PublicKey } from '@solana/web3.js';
 import BN from 'bn.js'; // Imported since FT codebase uses BN
 
 // Type definitions are snake_case to match the database schema
@@ -107,4 +108,37 @@ export type FastTransferId = {
   fast_vaa_hash?: string;
   fast_vaa_id?: string;
   auction_pubkey?: string;
+};
+
+// these can be found in the matchingEngineProgram, but we are making custom snake cased
+// types to match the events in the logs parsed. Somehow anchor does not automatically convert
+// the logs to the correct types
+export type AuctionUpdated = {
+  config_id: number;
+  auction: PublicKey;
+  vaa: PublicKey | null;
+  source_chain: number;
+  target_protocol: MessageProtocol;
+  redeemer_message_len: number;
+  end_slot: BN;
+  best_offer_token: PublicKey;
+  token_balance_before: BN;
+  amount_in: BN;
+  total_deposit: BN;
+  max_offer_price_allowed: BN;
+};
+
+export type MessageProtocol = {
+  Local?: {
+    program_id: PublicKey;
+  };
+  Cctp?: {
+    domain: number;
+  };
+  None?: {};
+};
+
+export type AuctionUpdatedEvent = {
+  name: 'AuctionUpdated';
+  data: AuctionUpdated;
 };

--- a/watcher/src/watchers/__tests__/FTSolanaWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/FTSolanaWatcher.test.ts
@@ -5,6 +5,7 @@ jest.setTimeout(60_000);
 
 // This test is working, but testing it is not very useful since the return value is just the lastBlockKey.
 // It is just an entrypoint to test the whole thing with a local postgres database.
+// Skipping because it requires db
 test.skip('getMessagesByBlock', async () => {
   const watcher = new FastTransferSolanaWatcher('Testnet');
   await watcher.getMessagesByBlock(301864980, 302864980);
@@ -197,7 +198,7 @@ test.skip('should fetch closed Auction', async () => {
   const watcher = new FastTransferSolanaWatcher('Testnet');
   const auction = await watcher.fetchAuction('FS4EAzWA2WuMKyGBy2C7EBvHL9W63NDX9JR4CPveAiDK');
 
-  if (!auction) {
+  if (!auction || !auction.info) {
     throw new Error('Auction not found');
   }
 
@@ -252,7 +253,7 @@ test('should fetch auction update from logs', async () => {
   if (!tx.meta?.logMessages) {
     throw new Error('No log messages');
   }
-  const auctionUpdate = await watcher.fetchEventFromLogs('AuctionUpdated', tx.meta.logMessages);
+  const auctionUpdate = await watcher.getAuctionUpdatedFromLogs(tx.meta.logMessages);
 
   if (!auctionUpdate) {
     throw new Error('Auction update not found');
@@ -261,7 +262,7 @@ test('should fetch auction update from logs', async () => {
   expect({
     config_id: 2,
     auction: auctionUpdate.auction.toString(),
-    vaa: auctionUpdate.vaa.toString(),
+    vaa: auctionUpdate.vaa?.toString(),
     source_chain: auctionUpdate.source_chain,
     target_protocol: {
       Local: {
@@ -295,6 +296,7 @@ test('should fetch auction update from logs', async () => {
   });
 });
 
+// Skipped because it requires database
 test.skip('should index all auction history', async () => {
   const watcher = new FastTransferSolanaWatcher('Testnet');
   await watcher.indexAuctionHistory('77W4Votv6bK1tyq4xcvyo2V9gXYknXBwcZ53XErgcEs9');


### PR DESCRIPTION
PR does a few things:
1. try to get auction from auction account 
    - if auction account is closed, grab the `auction_history` which the auction is in
        - if the auction <> auction history mapping is not indexed in the db, index the database 
         - if the mapping is in db, use this pubkey to query the `auction_history` account
2. query `message_protocol` from `AuctionUpdated` event
3. tests
    - query a closed auction 
    - update `executeFastOrderCctp`  txHash
4. add a table to auction history mapping