### PR TITLE
common: remove unused export

### DIFF
--- a/common/src/wormhole.ts
+++ b/common/src/wormhole.ts
@@ -1,5 +1,4 @@
 import { keccak256 } from '@wormhole-foundation/sdk-definitions';
-export { isBytes } from 'ethers/lib/utils';
 
 export interface GuardianSignature {
   index: number;


### PR DESCRIPTION
This export is preventing the cloud_functions from being deployed via scripts/deploy.sh.