### PR TITLE
Bing/ft watcher worker

### DIFF
--- a/common/src/consts.ts
+++ b/common/src/consts.ts
@@ -7,7 +7,7 @@ import {
   toChainId,
 } from '@wormhole-foundation/sdk-base';
 
-export type Mode = 'vaa' | 'ntt';
+export type Mode = 'vaa' | 'ntt' | 'ft';
 
 // This is defined here in an effort to keep the number and text in sync.
 // The default value is not exported because the getMissThreshold() function should be used to get the value.
@@ -17,9 +17,9 @@ export const MISS_THRESHOLD_LABEL = '40 minutes';
 export const MAX_VAA_DECIMALS = 8;
 export const VAA_VERSION = 1;
 
-export const INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN: {
-  [key in Network]: { [key in Chain]?: string };
-} = {
+type NetworkChainBlockMapping = { [key in Network]: { [key in Chain]?: string } };
+
+export const INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN: NetworkChainBlockMapping = {
   ['Mainnet']: {
     Ethereum: '12959638',
     Terra: '4810000', // not sure exactly but this should be before the first known message
@@ -84,9 +84,7 @@ export const INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN: {
   ['Devnet']: {},
 };
 
-export const INITIAL_NTT_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN: {
-  [key in Network]: { [key in Chain]?: string };
-} = {
+export const INITIAL_NTT_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN: NetworkChainBlockMapping = {
   ['Mainnet']: {
     Solana: '260508723',
     Ethereum: '19583505',
@@ -103,6 +101,23 @@ export const INITIAL_NTT_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN: {
     OptimismSepolia: '9232548',
   },
   ['Devnet']: {},
+};
+
+export const INITIAL_FT_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN: NetworkChainBlockMapping = {
+  ['Mainnet']: {},
+  ['Testnet']: {
+    Solana: '302162456',
+    ArbitrumSepolia: '49505590',
+  },
+  ['Devnet']: {},
+};
+
+export const INITIAL_DEPLOYMENT_BLOCK_BY_MODE: {
+  [mode in Mode]: NetworkChainBlockMapping;
+} = {
+  vaa: INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN,
+  ntt: INITIAL_NTT_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN,
+  ft: INITIAL_FT_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN,
 };
 
 export function getMissThreshold(date: Date, chainish: number | string | Chain | ChainId): string {

--- a/common/src/utils.ts
+++ b/common/src/utils.ts
@@ -36,7 +36,7 @@ export function getNetwork(): Network {
 
 export function getMode(): Mode {
   const mode: string = assertEnvironmentVariable('MODE').toLowerCase();
-  if (mode === 'vaa' || mode === 'ntt') {
+  if (mode === 'vaa' || mode === 'ntt' || mode === 'ft') {
     return mode;
   }
   throw new Error(`Unknown mode: ${mode}`);

--- a/database/fast-transfer-schema.sql
+++ b/database/fast-transfer-schema.sql
@@ -14,8 +14,11 @@ CREATE TYPE FastTransferStatus AS ENUM ('pending', 'no_offer', 'executed', 'sett
 -- Market Order tracks events of when fast market orders are
 -- placed in the token router
 CREATE TABLE market_orders (
-  fast_vaa_id VARCHAR(255) PRIMARY KEY,
-  fast_vaa_hash VARCHAR(255),
+  -- These two cant be primary key because on different stages they might initially be null due to the inability to find them
+  -- To accomodate this we put a unique constraint to allow nullable
+  -- It will eventually be filled up 
+  fast_vaa_id VARCHAR(255) UNIQUE,
+  fast_vaa_hash VARCHAR(255) UNIQUE,
   amount_in BIGINT,
   min_amount_out BIGINT,
   src_chain INTEGER,
@@ -89,4 +92,3 @@ CREATE TABLE auction_history_mapping (
   auction_pubkey VARCHAR(255) PRIMARY KEY,
   index INT NOT NULL
 );
-

--- a/watcher/scripts/backfill.ts
+++ b/watcher/scripts/backfill.ts
@@ -30,7 +30,7 @@ import { ChainId, toChain } from '@wormhole-foundation/sdk-base';
   const lastBlockEntries = Object.entries(localDb.lastBlockByChain);
   for (const [chain, blockKey] of lastBlockEntries) {
     console.log('backfilling last block for', chain, blockKey);
-    await remoteDb.storeLatestBlock(toChain(Number(chain) as ChainId), blockKey, false);
+    await remoteDb.storeLatestBlock(toChain(Number(chain) as ChainId), blockKey, 'vaa');
     await sleep(500);
   }
 })();

--- a/watcher/scripts/backfillNear.ts
+++ b/watcher/scripts/backfillNear.ts
@@ -35,7 +35,7 @@ const BATCH_SIZE = 100;
   const chain: Chain = 'Near';
   const provider = await getNearProvider(network, NEAR_ARCHIVE_RPC);
   const fromBlock = Number(
-    (await db.getLastBlockByChain(chain, false)) ??
+    (await db.getLastBlockByChain(chain, 'vaa')) ??
       INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN[network][chain] ??
       0
   );

--- a/watcher/src/databases/BigtableDatabase.ts
+++ b/watcher/src/databases/BigtableDatabase.ts
@@ -49,7 +49,6 @@ export class BigtableDatabase extends Database {
     this.signedVAAsTableId = assertEnvironmentVariable('BIGTABLE_SIGNED_VAAS_TABLE_ID');
     this.vaasByTxHashTableId = assertEnvironmentVariable('BIGTABLE_VAAS_BY_TX_HASH_TABLE_ID');
     this.instanceId = assertEnvironmentVariable('BIGTABLE_INSTANCE_ID');
-    // TODO: make these const?
     this.latestCollectionName = assertEnvironmentVariable('FIRESTORE_LATEST_COLLECTION');
     this.latestNTTCollectionName = assertEnvironmentVariable('FIRESTORE_LATEST_NTT_COLLECTION');
     this.latestFTCollectionName = assertEnvironmentVariable('FIRESTORE_LATEST_FT_COLLECTION');

--- a/watcher/src/databases/Database.ts
+++ b/watcher/src/databases/Database.ts
@@ -1,3 +1,4 @@
+import { Mode } from '@wormhole-foundation/wormhole-monitor-common';
 import { getLogger, WormholeLogger } from '../utils/logger';
 import { VaasByBlock } from './types';
 import { Chain } from '@wormhole-foundation/sdk-base';
@@ -14,13 +15,13 @@ export class Database {
     }
     return filteredVaasByBlock;
   }
-  async getLastBlockByChain(chain: Chain, isNTT: boolean): Promise<string | null> {
+  async getLastBlockByChain(chain: Chain, mode: Mode): Promise<string | null> {
     throw new Error('Not Implemented');
   }
   async storeVaasByBlock(chain: Chain, vaasByBlock: VaasByBlock): Promise<void> {
     throw new Error('Not Implemented');
   }
-  async storeLatestBlock(chain: Chain, lastBlockKey: string, isNTT: boolean): Promise<void> {
+  async storeLatestBlock(chain: Chain, lastBlockKey: string, mode: Mode): Promise<void> {
     throw new Error('Not Implemented');
   }
 }

--- a/watcher/src/databases/JsonDatabase.ts
+++ b/watcher/src/databases/JsonDatabase.ts
@@ -3,6 +3,7 @@ import { DB_LAST_BLOCK_FILE, JSON_DB_FILE } from '../consts';
 import { Database } from './Database';
 import { DB, LastBlockByChain, VaasByBlock } from './types';
 import { Chain, chainToChainId } from '@wormhole-foundation/sdk-base';
+import { Mode } from '@wormhole-foundation/wormhole-monitor-common';
 
 const ENCODING = 'utf8';
 export class JsonDatabase extends Database {
@@ -34,7 +35,7 @@ export class JsonDatabase extends Database {
     }
   }
 
-  async getLastBlockByChain(chain: Chain): Promise<string | null> {
+  async getLastBlockByChain(chain: Chain, mode: Mode): Promise<string | null> {
     const chainId = chainToChainId(chain);
     const blockInfo = this.lastBlockByChain[chainId];
     if (blockInfo) {

--- a/watcher/src/databases/__tests__/utils.test.ts
+++ b/watcher/src/databases/__tests__/utils.test.ts
@@ -10,11 +10,11 @@ test('getResumeBlockByChain', async () => {
   const blockKey = makeBlockKey(fauxBlock, new Date().toISOString());
   db.lastBlockByChain = { [chainToChainId('Solana')]: blockKey };
   // if a chain is in the database, that number should be returned
-  expect(await db.getLastBlockByChain('Solana')).toEqual(fauxBlock);
-  expect(await getResumeBlockByChain('Mainnet', 'Solana', false)).toEqual(Number(fauxBlock) + 1);
+  expect(await db.getLastBlockByChain('Solana', 'vaa')).toEqual(fauxBlock);
+  expect(await getResumeBlockByChain('Mainnet', 'Solana', 'vaa')).toEqual(Number(fauxBlock) + 1);
   // if a chain is not in the database, the initial deployment block should be returned
   expect(INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN['Mainnet'].Moonbeam).toBeDefined();
-  expect(await getResumeBlockByChain('Mainnet', 'Moonbeam', false)).toEqual(
+  expect(await getResumeBlockByChain('Mainnet', 'Moonbeam', 'vaa')).toEqual(
     Number(INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN['Mainnet'].Moonbeam)
   );
 });

--- a/watcher/src/databases/utils.ts
+++ b/watcher/src/databases/utils.ts
@@ -1,8 +1,8 @@
 import { Chain, Network, chainToChainId } from '@wormhole-foundation/sdk-base';
 import {
-  INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN,
-  INITIAL_NTT_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN,
+  INITIAL_DEPLOYMENT_BLOCK_BY_MODE,
   MAX_UINT_64,
+  Mode,
   padUint16,
   padUint64,
 } from '@wormhole-foundation/wormhole-monitor-common';
@@ -52,20 +52,18 @@ export const initDb = (startWatching: boolean = true): Database => {
 export const storeLatestBlock = async (
   chain: Chain,
   lastBlockKey: string,
-  isNTT: boolean
+  mode: Mode
 ): Promise<void> => {
-  return database.storeLatestBlock(chain, lastBlockKey, isNTT);
+  return database.storeLatestBlock(chain, lastBlockKey, mode);
 };
 
 export const getResumeBlockByChain = async (
   network: Network,
   chain: Chain,
-  isNTT: boolean
+  mode: Mode
 ): Promise<number | null> => {
-  const lastBlock = await database.getLastBlockByChain(chain, isNTT);
-  const initialBlock = isNTT
-    ? INITIAL_NTT_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN[network][chain]
-    : INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN[network][chain];
+  const lastBlock = await database.getLastBlockByChain(chain, mode);
+  const initialBlock = INITIAL_DEPLOYMENT_BLOCK_BY_MODE[mode][network][chain];
   return lastBlock !== null
     ? Number(lastBlock) + 1
     : initialBlock !== undefined

--- a/watcher/src/index.ts
+++ b/watcher/src/index.ts
@@ -2,7 +2,6 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 import { initDb } from './databases/utils';
-import { makeFinalizedNTTWatcher, makeFinalizedWatcher } from './watchers/utils';
 import { Mode, getNetwork, getMode } from '@wormhole-foundation/wormhole-monitor-common';
 import { startSupervisor } from './workers/supervisor';
 import { Chain, Network } from '@wormhole-foundation/sdk-base';
@@ -91,10 +90,14 @@ const supportedNTTChains: Chain[] =
     ? ['Solana', 'Sepolia', 'ArbitrumSepolia', 'BaseSepolia', 'OptimismSepolia']
     : ['Solana', 'Ethereum', 'Fantom', 'Arbitrum', 'Optimism', 'Base'];
 
+const supportedFTChains: Chain[] = network === 'Testnet' ? ['Solana', 'ArbitrumSepolia'] : [];
+
 if (mode === 'vaa') {
   startSupervisor(supportedChains);
 } else if (mode === 'ntt') {
   startSupervisor(supportedNTTChains);
+} else if (mode === 'ft') {
+  startSupervisor(supportedFTChains);
 } else {
   throw new Error(`Unknown mode: ${mode}`);
 }

--- a/watcher/src/watchers/FTSolanaWatcher.ts
+++ b/watcher/src/watchers/FTSolanaWatcher.ts
@@ -52,7 +52,7 @@ import {
 } from '../fastTransfer/consts';
 import { FastMarketOrder } from '@wormhole-foundation/example-liquidity-layer-definitions';
 
-export class FastTransferSolanaWatcher extends SolanaWatcher {
+export class FTSolanaWatcher extends SolanaWatcher {
   readonly network: Network;
   readonly rpc: string;
   readonly matchingEngineBorshCoder: BorshCoder;
@@ -65,7 +65,7 @@ export class FastTransferSolanaWatcher extends SolanaWatcher {
   readonly eventParser: EventParser;
 
   constructor(network: Network, isTest: boolean = false) {
-    super(network, false);
+    super(network, 'ft');
 
     this.getSignaturesLimit = 100;
     this.network = network;
@@ -108,7 +108,7 @@ export class FastTransferSolanaWatcher extends SolanaWatcher {
   }
 
   // TODO: Modify this so watcher can actually call this function (Add enum for mode)
-  async getMessagesByBlock(fromSlot: number, toSlot: number): Promise<string> {
+  async getFtMessagesForBlocks(fromSlot: number, toSlot: number): Promise<string> {
     if (fromSlot > toSlot) throw new Error('solana: invalid block range');
 
     this.logger.info(`fetching info for blocks ${fromSlot} to ${toSlot}`);
@@ -982,7 +982,7 @@ export class FastTransferSolanaWatcher extends SolanaWatcher {
     try {
       const result = await this.pg('market_orders')
         .insert(update)
-        .onConflict('fast_vaa_id')
+        .onConflict('fast_vaa_hash')
         .merge();
       this.logger.info(`Updated market order ${update.fast_vaa_id}. Result:`, result);
     } catch (error) {

--- a/watcher/src/watchers/FTSolanaWatcher.ts
+++ b/watcher/src/watchers/FTSolanaWatcher.ts
@@ -107,7 +107,6 @@ export class FTSolanaWatcher extends SolanaWatcher {
     });
   }
 
-  // TODO: Modify this so watcher can actually call this function (Add enum for mode)
   async getFtMessagesForBlocks(fromSlot: number, toSlot: number): Promise<string> {
     if (fromSlot > toSlot) throw new Error('solana: invalid block range');
 

--- a/watcher/src/watchers/NTTSolanaWatcher.ts
+++ b/watcher/src/watchers/NTTSolanaWatcher.ts
@@ -86,7 +86,7 @@ export class NTTSolanaWatcher extends SolanaWatcher {
   pg: Knex;
 
   constructor(network: Network) {
-    super(network, true);
+    super(network, 'ntt');
     this.rpc = RPCS_BY_CHAIN[this.network].Solana!;
     this.programIds = NTT_MANAGER_CONTRACT_ARRAY[this.network].Solana!;
     this.connection = new Connection(this.rpc, COMMITMENT);

--- a/watcher/src/watchers/NTTWatcher.ts
+++ b/watcher/src/watchers/NTTWatcher.ts
@@ -58,7 +58,7 @@ export class NTTWatcher extends Watcher {
     chain: PlatformToChains<'Evm'>,
     finalizedBlockTag: BlockTag = 'latest'
   ) {
-    super(network, chain, true);
+    super(network, chain, 'ntt');
     this.lastTimestamp = 0;
     this.latestFinalizedBlockNumber = 0;
     this.finalizedBlockTag = finalizedBlockTag;

--- a/watcher/src/watchers/SolanaWatcher.ts
+++ b/watcher/src/watchers/SolanaWatcher.ts
@@ -12,6 +12,7 @@ import { RPCS_BY_CHAIN } from '../consts';
 import { VaasByBlock } from '../databases/types';
 import { makeBlockKey, makeVaaKey } from '../databases/utils';
 import {
+  Mode,
   isLegacyMessage,
   normalizeCompileInstruction,
   universalAddress_stripped,
@@ -37,8 +38,8 @@ export class SolanaWatcher extends Watcher {
 
   connection: Connection | undefined;
 
-  constructor(network: Network, isNTT: boolean = false) {
-    super(network, 'Solana', isNTT);
+  constructor(network: Network, mode: Mode = 'vaa') {
+    super(network, 'Solana', mode);
     this.rpc = RPCS_BY_CHAIN[this.network].Solana!;
     this.programId = contracts.coreBridge(this.network, 'Solana');
   }

--- a/watcher/src/watchers/Watcher.ts
+++ b/watcher/src/watchers/Watcher.ts
@@ -23,10 +23,10 @@ export class Watcher {
     this.chain = chain;
     this.mode = mode;
 
-    // `vaa` -> ''
+    // `vaa` -> 'VAA_'
     // `ntt` -> 'NTT_'
     // `ft` -> 'FT_'
-    const loggerPrefix = mode === 'vaa' ? '' : mode.toUpperCase() + '_';
+    const loggerPrefix = mode.toUpperCase() + '_';
     this.logger = getLogger(loggerPrefix + chain);
   }
 

--- a/watcher/src/watchers/__tests__/FTEVMWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/FTEVMWatcher.test.ts
@@ -54,6 +54,6 @@ describe('FTWatcher', () => {
   it.skip('should save fast transfers in range', async () => {
     const watcher = new FTWatcher('Testnet', 'ArbitrumSepolia');
 
-    await watcher.getResultsForBlocks(49505590, 49505594);
+    await watcher.getFtMessagesForBlocks(49505590, 49505594);
   });
 });

--- a/watcher/src/watchers/__tests__/FTSolanaWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/FTSolanaWatcher.test.ts
@@ -1,5 +1,5 @@
 import { jest, test, expect } from '@jest/globals';
-import { FastTransferSolanaWatcher } from '../FTSolanaWatcher';
+import { FTSolanaWatcher } from '../FTSolanaWatcher';
 
 jest.setTimeout(60_000);
 
@@ -7,12 +7,12 @@ jest.setTimeout(60_000);
 // It is just an entrypoint to test the whole thing with a local postgres database.
 // Skipping because it requires db
 test.skip('getMessagesByBlock', async () => {
-  const watcher = new FastTransferSolanaWatcher('Testnet');
-  await watcher.getMessagesByBlock(313236172, 314175735);
+  const watcher = new FTSolanaWatcher('Testnet');
+  await watcher.getFtMessagesForBlocks(313236172, 314175735);
 });
 
 test('placeInitialOfferCctp', async () => {
-  const watcher = new FastTransferSolanaWatcher('Testnet', true);
+  const watcher = new FTSolanaWatcher('Testnet', true);
 
   const txHash =
     '622s4otqmig2LB6AjnhvQv4gwBpUX9Ewnnh2XKa7YfsRhr4h1AU1GJRweii4C9rwqNzX1piMQ3jZQTMTv7aS4pyE';
@@ -66,7 +66,7 @@ test('placeInitialOfferCctp', async () => {
 });
 
 test('should parse improveOffer', async () => {
-  const watcher = new FastTransferSolanaWatcher('Testnet', true);
+  const watcher = new FTSolanaWatcher('Testnet', true);
 
   const txHash =
     '5jD1at1xF6KKj5BzCuNZEhfNpEU4ho19pkdccm9xvtxs2AhYN1F1WNMj7uGtkkr4SrzT3DPzdZbEKMP6u5FVLzLy';
@@ -106,7 +106,7 @@ test('should parse improveOffer', async () => {
 // TODO: solver is broken and not running after latest deployment,
 // will update tests when they are fixed and running
 test('should parse executeFastOrderLocal', async () => {
-  const watcher = new FastTransferSolanaWatcher('Testnet', true);
+  const watcher = new FTSolanaWatcher('Testnet', true);
   const txHash =
     '7AfmUeb6sM4HRLyw8ZmmaC5R2SFAzgQAH4YbD2fmnDmDPAcdxAk9Rhi3xktrGoE7bB2VHiBhs3JSvgiFzo6yUPr';
 
@@ -133,7 +133,7 @@ test('should parse executeFastOrderLocal', async () => {
 });
 
 test('should parse executeFastOrderCctp', async () => {
-  const watcher = new FastTransferSolanaWatcher('Testnet', true);
+  const watcher = new FTSolanaWatcher('Testnet', true);
   const txHash =
     '4XiWZGfB9KymYuNgJP7z7rMcKroN3VXYL1QWAevZ4HNTgB3tgj1EGPdaeSgFA8uhj4QUNTdtB7aSb7pxNM7Vd77p';
   const tx = await watcher.getConnection().getTransaction(txHash, {
@@ -160,7 +160,7 @@ test('should parse executeFastOrderCctp', async () => {
 });
 
 test('should parse settleAuctionComplete', async () => {
-  const watcher = new FastTransferSolanaWatcher('Testnet', true);
+  const watcher = new FTSolanaWatcher('Testnet', true);
   const txHash =
     '5L2tBfpE35gHBTRmqet4UUGoUJrwYZe6LVCLomVkEDU1TBXNbWW2Xs8pPT5Zz2JQgX2vS8pE4bxmyDEZxL9fBVbs';
   const tx = await watcher.getConnection().getTransaction(txHash, {
@@ -186,7 +186,7 @@ test('should parse settleAuctionComplete', async () => {
 });
 
 test('should parse settleAuctionNoneLocal', async () => {
-  const watcher = new FastTransferSolanaWatcher('Testnet', true);
+  const watcher = new FTSolanaWatcher('Testnet', true);
   const txHash =
     '3fdXiWz25RxQacjDtG1cW5K4qhMFtXHipz8waGrpZee2Q321aCftdjfQDNuU1kGiqsiixq7nkK4apXyB7cHWWxhX';
   const tx = await watcher.getConnection().getTransaction(txHash, {
@@ -213,7 +213,7 @@ test('should parse settleAuctionNoneLocal', async () => {
 
 // Skipping this since it requires database
 test.skip('should fetch closed Auction', async () => {
-  const watcher = new FastTransferSolanaWatcher('Testnet');
+  const watcher = new FTSolanaWatcher('Testnet');
   const auction = await watcher.fetchAuction('FS4EAzWA2WuMKyGBy2C7EBvHL9W63NDX9JR4CPveAiDK');
 
   if (!auction || !auction.info) {
@@ -257,7 +257,7 @@ test.skip('should fetch closed Auction', async () => {
 });
 
 test('should fetch auction update from logs', async () => {
-  const watcher = new FastTransferSolanaWatcher('Testnet', true);
+  const watcher = new FTSolanaWatcher('Testnet', true);
   const txHash =
     '2YJAG7smyau6GbuEQT9NHJmuj4BFQWc8XrF2CTsmh1m626ZEd681DJoRmzQQGhj51UATB84o8TqMMaehC8nsFrVa';
   const tx = await watcher.getConnection().getTransaction(txHash, {
@@ -316,6 +316,6 @@ test('should fetch auction update from logs', async () => {
 
 // Skipped because it requires database
 test.skip('should index all auction history', async () => {
-  const watcher = new FastTransferSolanaWatcher('Testnet');
+  const watcher = new FTSolanaWatcher('Testnet');
   await watcher.indexAuctionHistory('77W4Votv6bK1tyq4xcvyo2V9gXYknXBwcZ53XErgcEs9');
 });

--- a/watcher/src/watchers/utils.ts
+++ b/watcher/src/watchers/utils.ts
@@ -17,6 +17,8 @@ import { NTTWatcher } from './NTTWatcher';
 import { NTTArbitrumWatcher } from './NTTArbitrumWatcher';
 import { NTTSolanaWatcher } from './NTTSolanaWatcher';
 import { Chain, Network } from '@wormhole-foundation/sdk-base';
+import { FTEVMWatcher } from './FTEVMWatcher';
+import { FTSolanaWatcher } from './FTSolanaWatcher';
 
 export function makeFinalizedWatcher(network: Network, chainName: Chain): Watcher {
   if (chainName === 'Solana') {
@@ -109,6 +111,25 @@ export function makeFinalizedNTTWatcher(network: Network, chainName: Chain): Wat
       return new NTTArbitrumWatcher(network);
     } else if (chainName === 'Solana') {
       return new NTTSolanaWatcher(network);
+    } else {
+      throw new Error(
+        `Attempted to create finalized NTT watcher for unsupported testnet chain ${chainName}`
+      );
+    }
+  } else {
+    throw new Error(
+      `Attempted to create finalized NTT watcher for unsupported network ${network}, ${chainName}`
+    );
+  }
+}
+
+export function makeFinalizedFTWatcher(network: Network, chainName: Chain): Watcher {
+  if ('Testnet') {
+    // These are testnet only chains
+    if (chainName === 'ArbitrumSepolia') {
+      return new FTEVMWatcher(network, chainName, 'finalized');
+    } else if (chainName === 'Solana') {
+      return new FTSolanaWatcher(network);
     } else {
       throw new Error(
         `Attempted to create finalized NTT watcher for unsupported testnet chain ${chainName}`

--- a/watcher/src/workers/worker.ts
+++ b/watcher/src/workers/worker.ts
@@ -1,5 +1,9 @@
 import { initDb } from '../databases/utils';
-import { makeFinalizedNTTWatcher, makeFinalizedWatcher } from '../watchers/utils';
+import {
+  makeFinalizedNTTWatcher,
+  makeFinalizedWatcher,
+  makeFinalizedFTWatcher,
+} from '../watchers/utils';
 import { workerData } from 'worker_threads';
 
 initDb(false);
@@ -11,6 +15,8 @@ if (mode === 'vaa') {
   makeFinalizedWatcher(network, chain).watch();
 } else if (mode === 'ntt') {
   makeFinalizedNTTWatcher(network, chain).watch();
+} else if (mode === 'ft') {
+  makeFinalizedFTWatcher(network, chain).watch();
 } else {
   throw new Error(`Unknown mode: ${mode}`);
 }


### PR DESCRIPTION
This PR updates the watcher code such that `ft_watcher` can be run

main changes:
- add `ft` to `Mode` 
- add `INITIAL_DEPLOYMENT_BLOCK` for FT and add a reusable type called `NetworkChainBlockMapping`
- add map to map `INITIAL_DEPLOYMENT_BLOCK` to their modes
- add map to map collection name to their modes
- instead of using `isNTT` boolean use `Mode`
- update to some naming of classes and methods 

db updates:
- `fast_vaa_id` and `fast_vaa_hash` to be `UNIQUE` as at some point in time they might be null
