### PR TITLE
ft_watcher: add fill ids to link fast order execution and redeem swaps

### DIFF
--- a/common/src/solana.ts
+++ b/common/src/solana.ts
@@ -117,3 +117,13 @@ export async function makeRpcCall(
 export function decodeBase64Data(encodedData: string) {
   return new Uint8Array(Buffer.from(encodedData, 'base64'));
 }
+
+const SOLANA_SEQ_LOG = 'Program log: Sequence: ';
+export function parseWormholeSequenceFromLogs(logs: string[]): number | null {
+  for (const log of logs) {
+    if (log.startsWith(SOLANA_SEQ_LOG)) {
+      return parseInt(log.replace(SOLANA_SEQ_LOG, ''), 10);
+    }
+  }
+  return null;
+}

--- a/database/fast-transfer-schema.sql
+++ b/database/fast-transfer-schema.sql
@@ -58,7 +58,9 @@ CREATE TABLE fast_transfer_executions (
   execution_payer VARCHAR(255),
   execution_tx_hash VARCHAR(255),
   execution_slot BIGINT,
-  execution_time TIMESTAMP
+  execution_time TIMESTAMP,
+  -- fill_id can be a vaa id (cctp) or solana account pubkey (local)
+  fill_id VARCHAR(255),
 );
 
 -- Settlement is created when the settlement is created in the `settleFastTransfer`
@@ -96,11 +98,12 @@ CREATE TABLE auction_history_mapping (
 
 -- Redeem Swaps table to track the final swap before funds reach the user's account
 CREATE TABLE redeem_swaps (
-  fill_vaa_id VARCHAR(255) PRIMARY KEY,
+  -- fill_id can be a vaa id (cctp) or solana account pubkey (local)
+  fill_id VARCHAR(255) PRIMARY KEY,
   tx_hash VARCHAR(255) NOT NULL,
   recipient VARCHAR(255) NOT NULL,
   output_token VARCHAR(255) NOT NULL,
   output_amount BIGINT NOT NULL,
   relaying_fee BIGINT NOT NULL,
-  timestamp TIMESTAMP NOT NULL
+  redeem_time TIMESTAMP NOT NULL
 );

--- a/watcher/src/fastTransfer/swapLayer/parser.ts
+++ b/watcher/src/fastTransfer/swapLayer/parser.ts
@@ -61,9 +61,9 @@ class SwapLayerParser {
       recipient: swapEvent.args.recipient,
       output_amount: BigInt(swapEvent.args.outputAmount.toString()),
       output_token: swapEvent.args.outputToken,
-      timestamp: new Date(blockTime * 1000),
+      redeem_time: new Date(blockTime * 1000),
       relaying_fee: BigInt(swapEvent.args.relayingFee.toString()),
-      fill_vaa_id: fillVaaId,
+      fill_id: fillVaaId,
     };
   }
 

--- a/watcher/src/fastTransfer/types.ts
+++ b/watcher/src/fastTransfer/types.ts
@@ -55,6 +55,8 @@ export type FastTransferExecutionInfo = {
   execution_time: Date;
   execution_tx_hash: string;
   execution_slot: bigint;
+  // fill_id can be a vaa id (cctp) or a Solana public key
+  fill_id: string;
 };
 
 export type FastTransferSettledInfo = {
@@ -149,6 +151,6 @@ export type RedeemSwap = {
   output_token: string;
   output_amount: bigint;
   relaying_fee: bigint;
-  timestamp: Date;
-  fill_vaa_id: string;
+  redeem_time: Date;
+  fill_id: string;
 };

--- a/watcher/src/watchers/FTEVMWatcher.ts
+++ b/watcher/src/watchers/FTEVMWatcher.ts
@@ -8,7 +8,6 @@ import { AXIOS_CONFIG_JSON, RPCS_BY_CHAIN } from '../consts';
 import { makeBlockKey } from '../databases/utils';
 import TokenRouterParser from '../fastTransfer/tokenRouter/parser';
 import SwapLayerParser from '../fastTransfer/swapLayer/parser';
-import { MarketOrder, RedeemSwap } from '../fastTransfer/types';
 import { Block } from './EVMWatcher';
 import { BigNumber } from 'ethers';
 import axios from 'axios';
@@ -151,7 +150,7 @@ export class FTEVMWatcher extends Watcher {
     }
 
     if (swapLayerResults.length) {
-      await this.saveBatch(swapLayerResults, 'redeem_swaps', 'fill_vaa_id', fromBlock, toBlock);
+      await this.saveBatch(swapLayerResults, 'redeem_swaps', 'fill_id', fromBlock, toBlock);
     }
 
     // we do not need to compare the lastBlockTime from tokenRouter and swapLayer as they both use toBlock

--- a/watcher/src/watchers/__tests__/FTEVMWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/FTEVMWatcher.test.ts
@@ -123,8 +123,8 @@ describe('SwapLayerParser', () => {
       output_token: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
       output_amount: BigInt('20000000000'),
       relaying_fee: BigInt('10447500'),
-      timestamp: new Date(mockBlock.timestamp * 1000),
-      fill_vaa_id: '1/cb0406e59555bf0371b7c4fff1812a11a8d92dad02ad422062971d61dcce2cd0/2',
+      redeem_time: new Date(mockBlock.timestamp * 1000),
+      fill_id: '1/cb0406e59555bf0371b7c4fff1812a11a8d92dad02ad422062971d61dcce2cd0/2',
     });
   });
 });

--- a/watcher/src/watchers/__tests__/FTSolanaWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/FTSolanaWatcher.test.ts
@@ -129,6 +129,7 @@ test('should parse executeFastOrderLocal', async () => {
     execution_time: new Date('2024-05-23T15:58:23.000Z'),
     execution_tx_hash: txHash,
     fast_vaa_hash: 'fd99d2d20f7458cae97de7d7bcf94cbdc5ac734264fa495bf01f1748e28039da',
+    fill_id: 'B2qkDPs1gPh69uvKN5mbtHRAFtiMaZCe4vu6Wp3yaaJ1',
   });
 });
 
@@ -156,6 +157,7 @@ test('should parse executeFastOrderCctp', async () => {
     execution_slot: 301864332n,
     execution_time: new Date('2024-05-28T03:15:19.000Z'),
     fast_vaa_hash: '14a5187e40e4fd2b2950cd8332b4142259757f4cbf7cffcb7cc95249df8415b9',
+    fill_id: '1/3e374fcd3aaf2ed067f3c93d21416855ec7916cfd2c2127bcbc68b3b1fb73077/7970',
   });
 });
 


### PR DESCRIPTION
This PR links the redeem swaps in https://github.com/wormhole-foundation/wormhole-dashboard/pull/349 and the fast transfers executions to complete the lifecyle

How it works:
1. For CCTP fast transfers (where dest chains are EVM), matching engine (on Solana) will publish a fill VAA which will be used for redeeming the USDC on the EVM side.
2. For Local fast transfers (where dest chain is Solana), matching engine doesn't need to publish a fill VAA. Instead it creates a fast fill account on Solana which will be used to redeem USDC on Solana chain itself.

This is why `fill_id` can either be a vaa id or Solana account pubkey