### PR TITLE
fly: add a prometheus gossip metrics utility

### DIFF
--- a/fly/cmd/heartbeats/main.go
+++ b/fly/cmd/heartbeats/main.go
@@ -178,7 +178,7 @@ func main() {
 		guardians = testnetGuardians
 		knownEmitter = sdk.KnownTestnetEmitters
 		rpcUrl = "https://rpc.ankr.com/eth_holesky"
-		coreBridgeAddr = "0x706abc4E45D419950511e474C7B9Ed348A4a716c"
+		coreBridgeAddr = "0xa10f2eF61dE1f19f586ab8B6F2EbA89bACE63F7a"
 	} else if env == common.UnsafeDevNet {
 		guardians = devnetGuardians
 		knownEmitter = sdk.KnownDevnetEmitters

--- a/fly/cmd/heartbeats/main.go
+++ b/fly/cmd/heartbeats/main.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	tm "github.com/buger/goterm"
-	"github.com/certusone/wormhole/node/pkg/common"
+	node_common "github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/p2p"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
@@ -22,6 +22,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/wormhole-foundation/wormhole-monitor/fly/common"
 	"github.com/wormhole-foundation/wormhole-monitor/fly/utils"
 	"github.com/wormhole-foundation/wormhole/sdk"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -86,61 +87,6 @@ var currentObsvData map[uint]uint
 var currentObsvTable map[uint]uint
 var obsvRateRows []obsvRateRow
 
-type guardianEntry struct {
-	index   int
-	name    string
-	address string
-}
-
-var mainnetGuardians = []guardianEntry{
-	{0, "RockawayX", "0x5893B5A76c3f739645648885bDCcC06cd70a3Cd3"},
-	{1, "Staked", "0xfF6CB952589BDE862c25Ef4392132fb9D4A42157"},
-	{2, "Figment", "0x114De8460193bdf3A2fCf81f86a09765F4762fD1"},
-	{3, "ChainodeTech", "0x107A0086b32d7A0977926A205131d8731D39cbEB"},
-	{4, "Inotel", "0x8C82B2fd82FaeD2711d59AF0F2499D16e726f6b2"},
-	{5, "HashKey Cloud", "0x11b39756C042441BE6D8650b69b54EbE715E2343"},
-	{6, "ChainLayer", "0x54Ce5B4D348fb74B958e8966e2ec3dBd4958a7cd"},
-	{7, "xLabs", "0x15e7cAF07C4e3DC8e7C469f92C8Cd88FB8005a20"},
-	{8, "Forbole", "0x74a3bf913953D695260D88BC1aA25A4eeE363ef0"},
-	{9, "Staking Fund", "0x000aC0076727b35FBea2dAc28fEE5cCB0fEA768e"},
-	{10, "Moonlet", "0xAF45Ced136b9D9e24903464AE889F5C8a723FC14"},
-	{11, "P2P Validator", "0xf93124b7c738843CBB89E864c862c38cddCccF95"},
-	{12, "01node", "0xD2CC37A4dc036a8D232b48f62cDD4731412f4890"},
-	{13, "MCF", "0xDA798F6896A3331F64b48c12D1D57Fd9cbe70811"},
-	{14, "Everstake", "0x71AA1BE1D36CaFE3867910F99C09e347899C19C3"},
-	{15, "Chorus One", "0x8192b6E7387CCd768277c17DAb1b7a5027c0b3Cf"},
-	{16, "syncnode", "0x178e21ad2E77AE06711549CFBB1f9c7a9d8096e8"},
-	{17, "Triton", "0x5E1487F35515d02A92753504a8D75471b9f49EdB"},
-	{18, "Staking Facilities", "0x6FbEBc898F403E4773E95feB15E80C9A99c8348d"},
-}
-
-// Although there are multiple testnet guardians running, they all use the same key, so it looks like one.
-var testnetGuardians = []guardianEntry{
-	{0, "Testnet", "0x13947Bd48b18E53fdAeEe77F3473391aC727C638"},
-}
-
-var devnetGuardians = []guardianEntry{
-	{0, "guardian-0", "0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe"},
-	{1, "guardian-1", "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"},
-	{2, "guardian-2", "0x58076F561CC62A47087B567C86f986426dFCD000"},
-	{3, "guardian-3", "0xBd6e9833490F8fA87c733A183CD076a6cBD29074"},
-	{4, "guardian-4", "0xb853FCF0a5C78C1b56D15fCE7a154e6ebe9ED7a2"},
-	{5, "guardian-5", "0xAF3503dBD2E37518ab04D7CE78b630F98b15b78a"},
-	{6, "guardian-6", "0x785632deA5609064803B1c8EA8bB2c77a6004Bd1"},
-	{7, "guardian-7", "0x09a281a698C0F5BA31f158585B41F4f33659e54D"},
-	{8, "guardian-8", "0x3178443AB76a60E21690DBfB17f7F59F09Ae3Ea1"},
-	{9, "guardian-9", "0x647ec26ae49b14060660504f4DA1c2059E1C5Ab6"},
-	{10, "guardian-10", "0x810AC3D8E1258Bd2F004a94Ca0cd4c68Fc1C0611"},
-	{11, "guardian-11", "0x80610e96d645b12f47ae5cf4546b18538739e90F"},
-	{12, "guardian-12", "0x2edb0D8530E31A218E72B9480202AcBaeB06178d"},
-	{13, "guardian-13", "0xa78858e5e5c4705CdD4B668FFe3Be5bae4867c9D"},
-	{14, "guardian-14", "0x5Efe3A05Efc62D60e1D19fAeB56A80223CDd3472"},
-	{15, "guardian-15", "0xD791b7D32C05aBB1cc00b6381FA0c4928f0c56fC"},
-	{16, "guardian-16", "0x14Bc029B8809069093D712A3fd4DfAb31963597e"},
-	{17, "guardian-17", "0x246Ab29FC6EBeDf2D392a51ab2Dc5C59d0902A03"},
-	{18, "guardian-18", "0x132A84dFD920b35a3D0BA5f7A0635dF298F9033e"},
-}
-
 func main() {
 	flag.Parse()
 
@@ -158,8 +104,8 @@ func main() {
 		logger.Fatal("--env is required")
 	}
 
-	env, err := common.ParseEnvironment(*envStr)
-	if err != nil || (env != common.UnsafeDevNet && env != common.TestNet && env != common.MainNet) {
+	env, err := node_common.ParseEnvironment(*envStr)
+	if err != nil || (env != node_common.UnsafeDevNet && env != node_common.TestNet && env != node_common.MainNet) {
 		if *envStr == "" {
 			logger.Fatal("Please specify --env")
 		}
@@ -167,28 +113,28 @@ func main() {
 	}
 
 	// Build the set of guardians based on our environment, where the default is mainnet.
-	var guardians []guardianEntry
+	var guardians []common.GuardianEntry
 	var knownEmitter []sdk.EmitterInfo
-	if env == common.MainNet {
-		guardians = mainnetGuardians
+	if env == node_common.MainNet {
+		guardians = common.MainnetGuardians
 		knownEmitter = sdk.KnownEmitters
 		rpcUrl = "https://rpc.ankr.com/eth"
 		coreBridgeAddr = "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B"
-	} else if env == common.TestNet {
-		guardians = testnetGuardians
+	} else if env == node_common.TestNet {
+		guardians = common.TestnetGuardians
 		knownEmitter = sdk.KnownTestnetEmitters
 		rpcUrl = "https://rpc.ankr.com/eth_holesky"
 		coreBridgeAddr = "0xa10f2eF61dE1f19f586ab8B6F2EbA89bACE63F7a"
-	} else if env == common.UnsafeDevNet {
-		guardians = devnetGuardians
+	} else if env == node_common.UnsafeDevNet {
+		guardians = common.DevnetGuardians
 		knownEmitter = sdk.KnownDevnetEmitters
 		rpcUrl = "http://localhost:8545"
 		coreBridgeAddr = "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550"
 	}
 
 	for _, gse := range guardians {
-		guardianIndexToNameMap[gse.index] = gse.name
-		guardianIndexMap[strings.ToLower(gse.address)] = gse.index
+		guardianIndexToNameMap[gse.Index] = gse.Name
+		guardianIndexMap[strings.ToLower(gse.Address)] = gse.Index
 	}
 
 	// Fill in the known emitters
@@ -251,7 +197,7 @@ func main() {
 	sendC := make(chan []byte)
 
 	// Inbound observations
-	obsvC := make(chan *common.MsgWithTimeStamp[gossipv1.SignedObservation], 20000)
+	obsvC := make(chan *node_common.MsgWithTimeStamp[gossipv1.SignedObservation], 20000)
 
 	// Inbound observation requests
 	obsvReqC := make(chan *gossipv1.ObservationRequest, 20000)
@@ -263,7 +209,7 @@ func main() {
 	heartbeatC := make(chan *gossipv1.Heartbeat, 20000)
 
 	// Guardian set state managed by processor
-	gst := common.NewGuardianSetState(heartbeatC)
+	gst := node_common.NewGuardianSetState(heartbeatC)
 
 	// Governor cfg
 	govConfigC := make(chan *gossipv1.SignedChainGovernorConfig, 20000)
@@ -276,7 +222,7 @@ func main() {
 		logger.Fatal("Failed to fetch guardian set", zap.Error(err))
 	}
 	logger.Info("guardian set", zap.Uint32("index", idx), zap.Any("gs", sgs))
-	gs := common.GuardianSet{
+	gs := node_common.GuardianSet{
 		Keys:  sgs.Keys,
 		Index: idx,
 	}
@@ -608,7 +554,7 @@ func main() {
 
 	// Load p2p private key
 	var priv crypto.PrivKey
-	priv, err = common.GetOrCreateNodeKey(logger, *nodeKeyPath)
+	priv, err = node_common.GetOrCreateNodeKey(logger, *nodeKeyPath)
 	if err != nil {
 		logger.Fatal("Failed to load node key", zap.Error(err))
 	}

--- a/fly/cmd/prom_gossip/Dockerfile
+++ b/fly/cmd/prom_gossip/Dockerfile
@@ -1,0 +1,11 @@
+FROM --platform=linux/amd64 docker.io/golang:1.21.9-bullseye@sha256:311468bffa9fa4747a334b94e6ce3681b564126d653675a6adc46698b2b88d35
+
+WORKDIR /app
+
+COPY . .
+
+WORKDIR /app/cmd/prom_gossip
+
+RUN go build main.go
+
+CMD [ "./main" ]

--- a/fly/cmd/prom_gossip/README.md
+++ b/fly/cmd/prom_gossip/README.md
@@ -1,0 +1,153 @@
+# Prometheus Gossip Metrics
+
+This utility provides additional Prometheus metrics for the gossip network
+
+To easily run all of the services with a preconfigured dashboard, from this folder, simply:
+
+```bash
+docker compose up
+```
+
+To view the dashboard, navigate to [http://localhost:3000](http://localhost:3000)
+
+Login with the default username and password: `admin`:`admin`
+
+Check out the automatically provisioned Gossip Metrics dashboard
+
+The rest of this document provides additional, advanced details
+
+## Run the service
+
+From this folder,
+
+```bash
+go run main.go
+```
+
+## Run a Prometheus server
+
+From this folder,
+
+```bash
+docker run -p 9090:9090 -v $(pwd)/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus
+```
+
+### View the metrics
+
+Navigate to [http://localhost:9090/graph](http://localhost:9090/graph)
+
+Try some useful queries:
+
+#### Gossip messages per second
+
+Total
+
+```
+sum(rate(gossip_by_type_total[1m]))
+```
+
+Per type
+
+```
+rate(gossip_by_type_total[1m])
+```
+
+#### Unique Observations / VAAs per second
+
+Observations
+
+```
+rate(gossip_observations_unique_total[1m])
+```
+
+VAAs
+
+```
+rate(gossip_vaas_unique_total[1m])
+```
+
+#### Observations by Guardian / Chain
+
+Per second by guardian and chain
+
+```
+rate(gossip_observations_by_guardian_per_chain_total[1m])
+```
+
+Sum by guardian
+
+```
+sum by (guardian_name) (gossip_observations_by_guardian_per_chain_total)
+```
+
+Sum by chain
+
+```
+sum by (chain_name) (gossip_observations_by_guardian_per_chain_total)
+```
+
+Per second by chain
+
+```
+sum by (chain_name) (rate(gossip_observations_by_guardian_per_chain_total[1m]))
+```
+
+#### Token Bridge observations by Guardian / Chain
+
+Per second by guardian and chain
+
+```
+rate(gossip_token_bridge_observations_by_guardian_per_chain_total[1m])
+```
+
+Sum by guardian
+
+```
+sum by (guardian_name) (gossip_token_bridge_observations_by_guardian_per_chain_total)
+```
+
+Sum by chain
+
+```
+sum by (chain_name) (gossip_token_bridge_observations_by_guardian_per_chain_total)
+```
+
+Per second by chain
+
+```
+sum by (chain_name) (rate(gossip_token_bridge_observations_by_guardian_per_chain_total[1m]))
+```
+
+## Run a Grafana server
+
+```bash
+docker run -p 3000:3000 grafana/grafana-oss
+```
+
+### Add a data source
+
+To add the Prometheus server as a data source
+
+- Connections
+- Data sources
+- Add data source
+- Prometheus
+- Connection - `http://prometheus:9090`
+- Save & test
+
+### Import a dashboard
+
+To import the provided `gossip_metrics.json` dashboard
+
+- Dashboards
+- New
+- Import
+- Drag and drop or copy and paste the contents of `dashboards/gossip_metrics.json`
+- Load
+- Import
+
+### Exporting a data source and provisioning it at startup
+
+After logging in, navigate to [http://localhost:3000/api/datasources](http://localhost:3000/api/datasources)
+
+See [https://grafana.com/docs/grafana/latest/administration/provisioning/](https://grafana.com/docs/grafana/latest/administration/provisioning/) for details on provisioning.

--- a/fly/cmd/prom_gossip/compose.yml
+++ b/fly/cmd/prom_gossip/compose.yml
@@ -1,0 +1,20 @@
+services:
+  gossip:
+    build:
+      context: ../..
+      dockerfile: cmd/prom_gossip/Dockerfile
+    ports:
+      - '2112:2112'
+  prometheus:
+    image: 'prom/prometheus'
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+  grafana:
+    image: 'grafana/grafana-oss'
+    ports:
+      - '3000:3000'
+    volumes:
+      - ./provisioning:/etc/grafana/provisioning
+      - ./dashboards:/var/lib/grafana/dashboards

--- a/fly/cmd/prom_gossip/dashboards/gossip_metrics.json
+++ b/fly/cmd/prom_gossip/dashboards/gossip_metrics.json
@@ -1,0 +1,784 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adutsqgjsne9sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adutsqgjsne9sb"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(gossip_by_type_total[1m]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Gossip MPS",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adutsqgjsne9sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "displayName": "${__field.labels.type}",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "displayMode": "lcd",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adutsqgjsne9sb"
+          },
+          "editorMode": "code",
+          "expr": "rate(gossip_by_type_total[1m])",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MPS by Type",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adutsqgjsne9sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adutsqgjsne9sb"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(gossip_by_type_total[1m]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Gossip MPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adutsqgjsne9sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "displayName": "${__field.labels.type}",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adutsqgjsne9sb"
+          },
+          "editorMode": "code",
+          "expr": "rate(gossip_by_type_total[1m])",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MPS by Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adutsqgjsne9sb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adutsqgjsne9sb"
+          },
+          "editorMode": "code",
+          "expr": "rate(gossip_observations_unique_total[1m])",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unique Observations / Sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adutsqgjsne9sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adutsqgjsne9sb"
+          },
+          "editorMode": "code",
+          "expr": "rate(gossip_vaas_unique_total[1m])",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unique VAAs / Sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adutsqgjsne9sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adutsqgjsne9sb"
+          },
+          "editorMode": "code",
+          "expr": "sum by (chain_name) (rate(gossip_observations_by_guardian_per_chain_total[1m]))\n",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "OPS by Chain",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adutsqgjsne9sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 9,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adutsqgjsne9sb"
+          },
+          "editorMode": "code",
+          "expr": "sum by (guardian_name) (rate(gossip_observations_by_guardian_per_chain_total[1m]))\n",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "OPS by Guardian",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "adutsqgjsne9sb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "displayName": "${__field.labels.guardian_name}:${__field.labels.chain_name}",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "adutsqgjsne9sb"
+          },
+          "editorMode": "code",
+          "expr": "rate(gossip_observations_by_guardian_per_chain_total[1m])\n",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "OPS By Guardian and Chain",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Gossip Metrics",
+  "uid": "fdupqfwp0s2kgf",
+  "version": 1,
+  "weekStart": ""
+}

--- a/fly/cmd/prom_gossip/main.go
+++ b/fly/cmd/prom_gossip/main.go
@@ -1,0 +1,461 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/p2p"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	ipfslog "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/wormhole-foundation/wormhole-monitor/fly/utils"
+	"github.com/wormhole-foundation/wormhole/sdk"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+
+	"go.uber.org/zap"
+)
+
+var (
+	envStr       = flag.String("env", "mainnet", `environment (may be "mainnet", "testnet" or "devnet", required)`)
+	logLevel     = flag.String("logLevel", "warn", "Logging level (debug, info, warn, error, dpanic, panic, fatal)")
+	p2pNetworkID = flag.String("network", "", "P2P network identifier (optional, overrides default, required for devnet)")
+	p2pPort      = flag.Uint("port", 8999, "P2P UDP listener port")
+	p2pBootstrap = flag.String("bootstrap", "", "P2P bootstrap peers (optional, overrides default)")
+	nodeKeyPath  = flag.String("nodeKey", "/tmp/node.key", "Path to node key (will be generated if it doesn't exist)")
+	ethRPC       = flag.String("ethRPC", "", "Ethereum RPC for fetching current guardian set (default is based on env)")
+	ethContract  = flag.String("ethContract", "", "Ethereum core bridge address for fetching current guardian set (default is based on env)")
+)
+
+var (
+	rootCtx       context.Context
+	rootCtxCancel context.CancelFunc
+
+	rpcUrl         string
+	coreBridgeAddr string
+
+	numGuardians int
+
+	// Guardian address to index map
+	guardianIndexMap = map[string]int{}
+
+	// Guardian index to address map
+	guardianIndexToNameMap = map[int]string{}
+
+	// The known token bridge emitters
+	knownEmitters = map[string]bool{}
+)
+
+type guardianEntry struct {
+	index   int
+	name    string
+	address string
+}
+
+var mainnetGuardians = []guardianEntry{
+	{0, "RockawayX", "0x5893B5A76c3f739645648885bDCcC06cd70a3Cd3"},
+	{1, "Staked", "0xfF6CB952589BDE862c25Ef4392132fb9D4A42157"},
+	{2, "Figment", "0x114De8460193bdf3A2fCf81f86a09765F4762fD1"},
+	{3, "ChainodeTech", "0x107A0086b32d7A0977926A205131d8731D39cbEB"},
+	{4, "Inotel", "0x8C82B2fd82FaeD2711d59AF0F2499D16e726f6b2"},
+	{5, "HashKey Cloud", "0x11b39756C042441BE6D8650b69b54EbE715E2343"},
+	{6, "ChainLayer", "0x54Ce5B4D348fb74B958e8966e2ec3dBd4958a7cd"},
+	{7, "xLabs", "0x15e7cAF07C4e3DC8e7C469f92C8Cd88FB8005a20"},
+	{8, "Forbole", "0x74a3bf913953D695260D88BC1aA25A4eeE363ef0"},
+	{9, "Staking Fund", "0x000aC0076727b35FBea2dAc28fEE5cCB0fEA768e"},
+	{10, "Moonlet", "0xAF45Ced136b9D9e24903464AE889F5C8a723FC14"},
+	{11, "P2P Validator", "0xf93124b7c738843CBB89E864c862c38cddCccF95"},
+	{12, "01node", "0xD2CC37A4dc036a8D232b48f62cDD4731412f4890"},
+	{13, "MCF", "0xDA798F6896A3331F64b48c12D1D57Fd9cbe70811"},
+	{14, "Everstake", "0x71AA1BE1D36CaFE3867910F99C09e347899C19C3"},
+	{15, "Chorus One", "0x8192b6E7387CCd768277c17DAb1b7a5027c0b3Cf"},
+	{16, "syncnode", "0x178e21ad2E77AE06711549CFBB1f9c7a9d8096e8"},
+	{17, "Triton", "0x5E1487F35515d02A92753504a8D75471b9f49EdB"},
+	{18, "Staking Facilities", "0x6FbEBc898F403E4773E95feB15E80C9A99c8348d"},
+}
+
+// Although there are multiple testnet guardians running, they all use the same key, so it looks like one.
+var testnetGuardians = []guardianEntry{
+	{0, "Testnet", "0x13947Bd48b18E53fdAeEe77F3473391aC727C638"},
+}
+
+var devnetGuardians = []guardianEntry{
+	{0, "guardian-0", "0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe"},
+	{1, "guardian-1", "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"},
+	{2, "guardian-2", "0x58076F561CC62A47087B567C86f986426dFCD000"},
+	{3, "guardian-3", "0xBd6e9833490F8fA87c733A183CD076a6cBD29074"},
+	{4, "guardian-4", "0xb853FCF0a5C78C1b56D15fCE7a154e6ebe9ED7a2"},
+	{5, "guardian-5", "0xAF3503dBD2E37518ab04D7CE78b630F98b15b78a"},
+	{6, "guardian-6", "0x785632deA5609064803B1c8EA8bB2c77a6004Bd1"},
+	{7, "guardian-7", "0x09a281a698C0F5BA31f158585B41F4f33659e54D"},
+	{8, "guardian-8", "0x3178443AB76a60E21690DBfB17f7F59F09Ae3Ea1"},
+	{9, "guardian-9", "0x647ec26ae49b14060660504f4DA1c2059E1C5Ab6"},
+	{10, "guardian-10", "0x810AC3D8E1258Bd2F004a94Ca0cd4c68Fc1C0611"},
+	{11, "guardian-11", "0x80610e96d645b12f47ae5cf4546b18538739e90F"},
+	{12, "guardian-12", "0x2edb0D8530E31A218E72B9480202AcBaeB06178d"},
+	{13, "guardian-13", "0xa78858e5e5c4705CdD4B668FFe3Be5bae4867c9D"},
+	{14, "guardian-14", "0x5Efe3A05Efc62D60e1D19fAeB56A80223CDd3472"},
+	{15, "guardian-15", "0xD791b7D32C05aBB1cc00b6381FA0c4928f0c56fC"},
+	{16, "guardian-16", "0x14Bc029B8809069093D712A3fd4DfAb31963597e"},
+	{17, "guardian-17", "0x246Ab29FC6EBeDf2D392a51ab2Dc5C59d0902A03"},
+	{18, "guardian-18", "0x132A84dFD920b35a3D0BA5f7A0635dF298F9033e"},
+}
+
+var (
+	gossipByType = promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "gossip_by_type_total",
+			Help: "The total number of gossip messages by type",
+	}, []string{"type"})
+	uniqueObservationsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "gossip_observations_unique_total",
+		Help: "The unique number of observations received over gossip",
+	})
+	observationsByGuardianPerChain = promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "gossip_observations_by_guardian_per_chain_total",
+			Help: "The number of observations received over gossip by guardian, per chain",
+	}, []string{"guardian_name", "chain_name"})
+	tbObservationsByGuardianPerChain = promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "gossip_token_bridge_observations_by_guardian_per_chain_total",
+			Help: "The number of token bridge observations received over gossip by guardian, per chain",
+	}, []string{"guardian_name", "chain_name"})
+	observationRequestsPerChain = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gossip_observation_requests_per_chain_total",
+		Help: "The number of observation requests received over gossip per chain",
+	}, []string{"chain_name"})
+	uniqueVAAsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "gossip_vaas_unique_total",
+		Help: "The unique number of vaas received over gossip",
+	})
+	heartbeatsByGuardian = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gossip_heartbeats_by_guardian_total",
+		Help: "The number of heartbeats received over gossip by guardian",
+	}, []string{"guardian_name"})
+	govConfigByGuardian = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gossip_gov_config_by_guardian_total",
+		Help: "The number of heartbeats received over gossip by guardian",
+	}, []string{"guardian_name"})
+	govStatusByGuardian = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gossip_gov_status_by_guardian_total",
+		Help: "The number of heartbeats received over gossip by guardian",
+	}, []string{"guardian_name"})
+)
+
+func main() {
+	flag.Parse()
+
+	// Set up the logger.
+	lvl, err := ipfslog.LevelFromString(*logLevel)
+	if err != nil {
+		fmt.Println("Invalid log level")
+		os.Exit(1)
+	}
+
+	logger := ipfslog.Logger("wormhole-fly").Desugar()
+	ipfslog.SetAllLoggers(lvl)
+
+	if *envStr == "" {
+		logger.Fatal("--env is required")
+	}
+
+	env, err := common.ParseEnvironment(*envStr)
+	if err != nil || (env != common.UnsafeDevNet && env != common.TestNet && env != common.MainNet) {
+		if *envStr == "" {
+			logger.Fatal("Please specify --env")
+		}
+		logger.Fatal("Invalid value for --env, should be devnet, testnet or mainnet", zap.String("val", *envStr))
+	}
+
+	// Build the set of guardians based on our environment, where the default is mainnet.
+	var guardians []guardianEntry
+	var knownEmitter []sdk.EmitterInfo
+	if env == common.MainNet {
+		guardians = mainnetGuardians
+		knownEmitter = sdk.KnownEmitters
+		rpcUrl = "https://rpc.ankr.com/eth"
+		coreBridgeAddr = "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B"
+	} else if env == common.TestNet {
+		guardians = testnetGuardians
+		knownEmitter = sdk.KnownTestnetEmitters
+		rpcUrl = "https://rpc.ankr.com/eth_holesky"
+		coreBridgeAddr = "0xa10f2eF61dE1f19f586ab8B6F2EbA89bACE63F7a"
+	} else if env == common.UnsafeDevNet {
+		guardians = devnetGuardians
+		knownEmitter = sdk.KnownDevnetEmitters
+		rpcUrl = "http://localhost:8545"
+		coreBridgeAddr = "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550"
+	}
+
+	for _, gse := range guardians {
+		guardianIndexToNameMap[gse.index] = gse.name
+		guardianIndexMap[strings.ToLower(gse.address)] = gse.index
+	}
+
+	// Fill in the known emitters
+	for _, knownEmitter := range knownEmitter {
+		knownEmitters[strings.ToLower(knownEmitter.Emitter)] = true
+	}
+
+	numGuardians = len(guardianIndexToNameMap)
+
+	// Set up P2P.
+	if *p2pNetworkID == "" {
+		*p2pNetworkID = p2p.GetNetworkId(env)
+	}
+
+	if *p2pBootstrap == "" {
+		*p2pBootstrap, err = p2p.GetBootstrapPeers(env)
+		if err != nil {
+			logger.Fatal("failed to determine the bootstrap peers from the environment", zap.String("env", string(env)), zap.Error(err))
+		}
+	}
+
+	// If they specified the RPC or contract address, override the defaults.
+	if *ethRPC != "" {
+		rpcUrl = *ethRPC
+	}
+	if *ethContract != "" {
+		coreBridgeAddr = *ethContract
+	}
+
+	// Node's main lifecycle context.
+	rootCtx, rootCtxCancel = context.WithCancel(context.Background())
+	defer rootCtxCancel()
+
+	// Outbound gossip message queue
+	sendC := make(chan []byte)
+
+	// Inbound observations
+	obsvC := make(chan *common.MsgWithTimeStamp[gossipv1.SignedObservation], 20000)
+
+	// Inbound observation requests
+	obsvReqC := make(chan *gossipv1.ObservationRequest, 20000)
+
+	// Inbound signed VAAs
+	signedInC := make(chan *gossipv1.SignedVAAWithQuorum, 20000)
+
+	// Heartbeat updates
+	heartbeatC := make(chan *gossipv1.Heartbeat, 20000)
+
+	// Guardian set state managed by processor
+	gst := common.NewGuardianSetState(heartbeatC)
+
+	// Governor cfg
+	govConfigC := make(chan *gossipv1.SignedChainGovernorConfig, 20000)
+
+	// Governor status
+	govStatusC := make(chan *gossipv1.SignedChainGovernorStatus, 20000)
+	// Bootstrap guardian set, otherwise heartbeats would be skipped
+	idx, sgs, err := utils.FetchCurrentGuardianSet(rpcUrl, coreBridgeAddr)
+	if err != nil {
+		logger.Fatal("Failed to fetch guardian set", zap.Error(err))
+	}
+	logger.Info("guardian set", zap.Uint32("index", idx), zap.Any("gs", sgs))
+	gs := common.GuardianSet{
+		Keys:  sgs.Keys,
+		Index: idx,
+	}
+	gst.Set(&gs)
+
+	if len(gs.Keys) != numGuardians {
+		logger.Error("Invalid number of guardians.", zap.Int("found", len(gs.Keys)), zap.Int("expected", numGuardians))
+		return
+	}
+
+	// Count observations
+	go func() {
+		uniqueObs := map[string]struct{}{}
+		for {
+			select {
+			case <-rootCtx.Done():
+				return
+			case o := <-obsvC:
+				gossipByType.WithLabelValues("observation").Inc()
+				spl := strings.Split(o.Msg.MessageId, "/")
+				chain, err := parseChainID(spl[0])
+				if err != nil {
+					chain = vaa.ChainIDUnset
+				}
+				emitter := strings.ToLower(spl[1])
+				addr := "0x" + string(hex.EncodeToString(o.Msg.Addr))
+				idx := guardianIndexMap[strings.ToLower(addr)]
+				name := guardianIndexToNameMap[idx]
+				observationsByGuardianPerChain.WithLabelValues(name, chain.String()).Inc()
+				if knownEmitters[emitter] {
+					tbObservationsByGuardianPerChain.WithLabelValues(name, chain.String()).Inc()
+				}
+				uniqueObs[hex.EncodeToString(o.Msg.Hash)] = struct{}{}
+				uniqueObservationsGauge.Set(float64(len(uniqueObs)))
+			}
+		}
+	}()
+
+	// Count observation requests
+	go func() {
+		for {
+			select {
+			case <-rootCtx.Done():
+				return
+			case or := <-obsvReqC:
+				// There is no guardian address in the observation request
+				gossipByType.WithLabelValues("observation_request").Inc()
+				chain := vaa.ChainID(or.ChainId)
+				observationRequestsPerChain.WithLabelValues(chain.String()).Inc()
+			}
+		}
+	}()
+
+	// Count signed VAAs
+	go func() {
+		uniqueVAAs := map[string]struct{}{}
+		for {
+			select {
+			case <-rootCtx.Done():
+				return
+			case m := <-signedInC:
+				// This only has VAABytes. It doesn't have the guardian address
+				gossipByType.WithLabelValues("vaa").Inc()
+				v, err := vaa.Unmarshal(m.Vaa)
+				if err != nil {
+					logger.Warn("received invalid VAA in SignedVAAWithQuorum message", zap.Error(err), zap.Any("message", m))
+				} else {
+					uniqueVAAs[v.HexDigest()] = struct{}{}
+					uniqueVAAsGauge.Set(float64(len(uniqueVAAs)))
+				}
+			}
+		}
+	}()
+
+	// Handle heartbeats
+	go func() {
+		for {
+			select {
+			case <-rootCtx.Done():
+				return
+			case hb := <-heartbeatC:
+				gossipByType.WithLabelValues("heartbeat").Inc()
+				idx := guardianIndexMap[strings.ToLower(hb.GuardianAddr)]
+				name := guardianIndexToNameMap[idx]
+				heartbeatsByGuardian.WithLabelValues(name).Inc()
+			}
+		}
+	}()
+
+	// Count govConfigs
+	go func() {
+		for {
+			select {
+			case <-rootCtx.Done():
+				return
+			case g := <-govConfigC:
+				gossipByType.WithLabelValues("gov_config").Inc()
+				addr := "0x" + string(hex.EncodeToString(g.GuardianAddr))
+				idx := guardianIndexMap[strings.ToLower(addr)]
+				name := guardianIndexToNameMap[idx]
+				govConfigByGuardian.WithLabelValues(name).Inc()
+			}
+		}
+	}()
+
+	// Count govStatus
+	go func() {
+		for {
+			select {
+			case <-rootCtx.Done():
+				return
+			case g := <-govStatusC:
+				gossipByType.WithLabelValues("gov_status").Inc()
+				addr := "0x" + string(hex.EncodeToString(g.GuardianAddr))
+				idx := guardianIndexMap[strings.ToLower(addr)]
+				name := guardianIndexToNameMap[idx]
+				govStatusByGuardian.WithLabelValues(name).Inc()
+			}
+		}
+	}()
+
+	// Start prometheus server
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+    	http.ListenAndServe(":2112", nil)
+	}()
+
+	// Load p2p private key
+	var priv crypto.PrivKey
+	priv, err = common.GetOrCreateNodeKey(logger, *nodeKeyPath)
+	if err != nil {
+		logger.Fatal("Failed to load node key", zap.Error(err))
+	}
+
+	// Run supervisor.
+	components := p2p.DefaultComponents()
+	components.Port = *p2pPort
+	supervisor.New(rootCtx, logger, func(ctx context.Context) error {
+		if err := supervisor.Run(ctx,
+			"p2p",
+			p2p.Run(obsvC,
+				obsvReqC,
+				nil,
+				sendC,
+				signedInC,
+				priv,
+				nil,
+				gst,
+				*p2pNetworkID,
+				*p2pBootstrap,
+				"",
+				false,
+				rootCtxCancel,
+				nil,
+				nil,
+				govConfigC,
+				govStatusC,
+				components,
+				nil,
+				false,
+				false,
+				nil,
+				nil,
+				"",
+				0,
+				"",
+			)); err != nil {
+			return err
+		}
+
+		logger.Info("Started internal services")
+
+		<-ctx.Done()
+		return nil
+	},
+		// It's safer to crash and restart the process in case we encounter a panic,
+		// rather than attempting to reschedule the runnable.
+		supervisor.WithPropagatePanic)
+
+	<-rootCtx.Done()
+	logger.Info("root context cancelled, exiting...")
+}
+
+// parseChainID parses a human-readable chain name or a chain ID.
+func parseChainID(name string) (vaa.ChainID, error) {
+	s, err := vaa.ChainIDFromString(name)
+	if err == nil {
+		return s, nil
+	}
+
+	// parse as uint16
+	i, err := strconv.ParseUint(name, 10, 16)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse as name or uint16: %v", err)
+	}
+
+	return vaa.ChainID(i), nil
+}

--- a/fly/cmd/prom_gossip/prometheus.yml
+++ b/fly/cmd/prom_gossip/prometheus.yml
@@ -1,0 +1,24 @@
+global:
+  scrape_interval: 15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'codelab-monitor'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'gossip'
+    scrape_interval: 10s
+    static_configs:
+      - targets:
+          - gossip:2112

--- a/fly/cmd/prom_gossip/provisioning/dashboards/automatic.yml
+++ b/fly/cmd/prom_gossip/provisioning/dashboards/automatic.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: git
+    orgId: 1
+    type: file
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/fly/cmd/prom_gossip/provisioning/datasources/automatic.yml
+++ b/fly/cmd/prom_gossip/provisioning/datasources/automatic.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    uid: adutsqgjsne9sb
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      httpMethod: POST

--- a/fly/common/consts.go
+++ b/fly/common/consts.go
@@ -10,3 +10,58 @@ const (
 
 	MessageUpdateBatchSize = 100
 )
+
+type GuardianEntry struct {
+	Index   int
+	Name    string
+	Address string
+}
+
+var MainnetGuardians = []GuardianEntry{
+	{0, "RockawayX", "0x5893B5A76c3f739645648885bDCcC06cd70a3Cd3"},
+	{1, "Staked", "0xfF6CB952589BDE862c25Ef4392132fb9D4A42157"},
+	{2, "Figment", "0x114De8460193bdf3A2fCf81f86a09765F4762fD1"},
+	{3, "ChainodeTech", "0x107A0086b32d7A0977926A205131d8731D39cbEB"},
+	{4, "Inotel", "0x8C82B2fd82FaeD2711d59AF0F2499D16e726f6b2"},
+	{5, "HashKey Cloud", "0x11b39756C042441BE6D8650b69b54EbE715E2343"},
+	{6, "ChainLayer", "0x54Ce5B4D348fb74B958e8966e2ec3dBd4958a7cd"},
+	{7, "xLabs", "0x15e7cAF07C4e3DC8e7C469f92C8Cd88FB8005a20"},
+	{8, "Forbole", "0x74a3bf913953D695260D88BC1aA25A4eeE363ef0"},
+	{9, "Staking Fund", "0x000aC0076727b35FBea2dAc28fEE5cCB0fEA768e"},
+	{10, "Moonlet", "0xAF45Ced136b9D9e24903464AE889F5C8a723FC14"},
+	{11, "P2P Validator", "0xf93124b7c738843CBB89E864c862c38cddCccF95"},
+	{12, "01node", "0xD2CC37A4dc036a8D232b48f62cDD4731412f4890"},
+	{13, "MCF", "0xDA798F6896A3331F64b48c12D1D57Fd9cbe70811"},
+	{14, "Everstake", "0x71AA1BE1D36CaFE3867910F99C09e347899C19C3"},
+	{15, "Chorus One", "0x8192b6E7387CCd768277c17DAb1b7a5027c0b3Cf"},
+	{16, "syncnode", "0x178e21ad2E77AE06711549CFBB1f9c7a9d8096e8"},
+	{17, "Triton", "0x5E1487F35515d02A92753504a8D75471b9f49EdB"},
+	{18, "Staking Facilities", "0x6FbEBc898F403E4773E95feB15E80C9A99c8348d"},
+}
+
+// Although there are multiple testnet guardians running, they all use the same key, so it looks like one.
+var TestnetGuardians = []GuardianEntry{
+	{0, "Testnet", "0x13947Bd48b18E53fdAeEe77F3473391aC727C638"},
+}
+
+var DevnetGuardians = []GuardianEntry{
+	{0, "guardian-0", "0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe"},
+	{1, "guardian-1", "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"},
+	{2, "guardian-2", "0x58076F561CC62A47087B567C86f986426dFCD000"},
+	{3, "guardian-3", "0xBd6e9833490F8fA87c733A183CD076a6cBD29074"},
+	{4, "guardian-4", "0xb853FCF0a5C78C1b56D15fCE7a154e6ebe9ED7a2"},
+	{5, "guardian-5", "0xAF3503dBD2E37518ab04D7CE78b630F98b15b78a"},
+	{6, "guardian-6", "0x785632deA5609064803B1c8EA8bB2c77a6004Bd1"},
+	{7, "guardian-7", "0x09a281a698C0F5BA31f158585B41F4f33659e54D"},
+	{8, "guardian-8", "0x3178443AB76a60E21690DBfB17f7F59F09Ae3Ea1"},
+	{9, "guardian-9", "0x647ec26ae49b14060660504f4DA1c2059E1C5Ab6"},
+	{10, "guardian-10", "0x810AC3D8E1258Bd2F004a94Ca0cd4c68Fc1C0611"},
+	{11, "guardian-11", "0x80610e96d645b12f47ae5cf4546b18538739e90F"},
+	{12, "guardian-12", "0x2edb0D8530E31A218E72B9480202AcBaeB06178d"},
+	{13, "guardian-13", "0xa78858e5e5c4705CdD4B668FFe3Be5bae4867c9D"},
+	{14, "guardian-14", "0x5Efe3A05Efc62D60e1D19fAeB56A80223CDd3472"},
+	{15, "guardian-15", "0xD791b7D32C05aBB1cc00b6381FA0c4928f0c56fC"},
+	{16, "guardian-16", "0x14Bc029B8809069093D712A3fd4DfAb31963597e"},
+	{17, "guardian-17", "0x246Ab29FC6EBeDf2D392a51ab2Dc5C59d0902A03"},
+	{18, "guardian-18", "0x132A84dFD920b35a3D0BA5f7A0635dF298F9033e"},
+}


### PR DESCRIPTION
The goal of this PR is to provide a utility which can provide active analytics of the gossip network. `fly/cmd/prom_gossip/main.go` does this by tracking prometheus metrics for the various gossip messages. The provided readme describes how to run a prometheus and grafana server to view the metrics and a provided dashboard.

Reviewers: please confirm that `docker compose up` and the resulting dashboard at [http://localhost:3000](http://localhost:3000) works for you (more detailed instructions in the readme).