### PR TITLE
watcher: reduce Klaytn batch size

### DIFF
--- a/watcher/src/watchers/EVMWatcher.ts
+++ b/watcher/src/watchers/EVMWatcher.ts
@@ -42,7 +42,7 @@ export class EVMWatcher extends Watcher {
     this.finalizedBlockTag = finalizedBlockTag;
     if (chain === 'Acala' || chain === 'Karura' || chain === 'Berachain') {
       this.maximumBatchSize = 50;
-    } else if (chain === 'Snaxchain') {
+    } else if (chain === 'Snaxchain' || chain === 'Klaytn') {
       this.maximumBatchSize = 10;
     }
   }


### PR DESCRIPTION
Not sure why this is a thing now.  But Ankr has reduced the allowed batch size for Klaytn.