### PR TITLE
Fix for batches in heartbeats tool

### DIFF
--- a/fly/cmd/heartbeats/main.go
+++ b/fly/cmd/heartbeats/main.go
@@ -374,11 +374,13 @@ func main() {
 				}
 				gossipLock.Unlock()
 			case batch := <-batchObsvC:
+				addr := "0x" + string(hex.EncodeToString(batch.Msg.Addr))
+				idx := guardianIndexMap[strings.ToLower(addr)]
+				gossipCounter[idx][GSM_signedObservationBatch]++
+				gossipCounter[totalsRow][GSM_signedObservationBatch]++
 				for _, o := range batch.Msg.Observations {
 					spl := strings.Split(o.MessageId, "/")
 					emitter := strings.ToLower(spl[1])
-					addr := "0x" + string(hex.EncodeToString(batch.Msg.Addr))
-					idx := guardianIndexMap[strings.ToLower(addr)]
 					if knownEmitters[emitter] {
 						gossipCounter[idx][GSM_tbObservation]++
 						gossipCounter[totalsRow][GSM_tbObservation]++


### PR DESCRIPTION
Minor tweak for handling of batch observations in the `heartbeats` tool. Although this tool will be replaced by the `prom_gossip` tool in most cases, it is still useful in the guardian load testing environment, so it is worth fixing.