### PR TITLE
Ft/fix swap layer

### DIFF
--- a/common/src/solana.ts
+++ b/common/src/solana.ts
@@ -174,7 +174,5 @@ export function getTokenBalanceChange(
   const change =
     BigInt(postTokenBalance.uiTokenAmount.amount) - BigInt(preTokenBalance.uiTokenAmount.amount);
 
-  console.log(`Token balance change for owner ${owner} and mint ${mint}: ${change}`);
-
   return change;
 }

--- a/common/src/solana.ts
+++ b/common/src/solana.ts
@@ -151,17 +151,19 @@ export function blockTimeToDate(blockTime: number) {
 export function getTokenBalanceChange(
   transaction: VersionedTransactionResponse,
   owner: string,
-  mint: string
+  mint: string,
 ) {
-  console.log('Transaction Meta:', transaction.meta);
   const preTokenBalances = transaction.meta?.preTokenBalances || [];
   const postTokenBalances = transaction.meta?.postTokenBalances || [];
+
+  console.log(`Owner: ${owner}, Mint: ${mint}`);
 
   const preTokenBalance = preTokenBalances.find((tb) => tb.mint === mint && tb.owner === owner) || {
     uiTokenAmount: {
       amount: 0n,
     },
   };
+  console.log(`Pre-transaction token balance: ${preTokenBalance.uiTokenAmount.amount}`);
 
   const postTokenBalance = postTokenBalances.find(
     (tb) => tb.mint === mint && tb.owner === owner
@@ -170,6 +172,7 @@ export function getTokenBalanceChange(
       amount: 0n,
     },
   };
+  console.log(`Post-transaction token balance: ${postTokenBalance.uiTokenAmount.amount}`);
 
   const change =
     BigInt(postTokenBalance.uiTokenAmount.amount) - BigInt(preTokenBalance.uiTokenAmount.amount);

--- a/common/src/solana.ts
+++ b/common/src/solana.ts
@@ -153,6 +153,7 @@ export function getTokenBalanceChange(
   owner: string,
   mint: string
 ) {
+  console.log('Transaction Meta:', transaction.meta);
   const preTokenBalances = transaction.meta?.preTokenBalances || [];
   const postTokenBalances = transaction.meta?.postTokenBalances || [];
 
@@ -172,6 +173,8 @@ export function getTokenBalanceChange(
 
   const change =
     BigInt(postTokenBalance.uiTokenAmount.amount) - BigInt(preTokenBalance.uiTokenAmount.amount);
+
+  console.log(`Token balance change for owner ${owner} and mint ${mint}: ${change}`);
 
   return change;
 }

--- a/database/fast-transfer-schema.sql
+++ b/database/fast-transfer-schema.sql
@@ -107,7 +107,7 @@ CREATE TABLE redeem_swaps (
   output_token VARCHAR(255) NOT NULL,
   output_amount BIGINT NOT NULL,
   relaying_fee BIGINT NOT NULL,
-  redeem_time TIMESTAMP NOT NULL,
+  redeem_time TIMESTAMP,
   staged_inbound VARCHAR(255)
 );
 

--- a/database/fast-transfer-schema.sql
+++ b/database/fast-transfer-schema.sql
@@ -19,7 +19,7 @@ CREATE TYPE FastTransferStatus AS ENUM ('pending', 'no_offer', 'executed', 'sett
 CREATE TABLE market_orders (
   -- These two cant be primary key because on different stages they might initially be null due to the inability to find them
   -- To accomodate this we put a unique constraint to allow nullable
-  -- It will eventually be filled up 
+  -- It will eventually be filled up
   fast_vaa_id VARCHAR(255) UNIQUE,
   fast_vaa_hash VARCHAR(255) UNIQUE,
   amount_in BIGINT,
@@ -107,14 +107,15 @@ CREATE TABLE redeem_swaps (
   output_token VARCHAR(255) NOT NULL,
   output_amount BIGINT NOT NULL,
   relaying_fee BIGINT NOT NULL,
-  redeem_time TIMESTAMP NOT NULL
+  redeem_time TIMESTAMP NOT NULL,
+  staged_inbound VARCHAR(255)
 );
 
 -- Normalized table for chain name reference
 CREATE TABLE chains (
   id INTEGER PRIMARY KEY,
   name VARCHAR(255) NOT NULL UNIQUE
-)
+);
 
 -- Token Infos table to store information about different tokens
 -- A normalized table for us to reference token info for analytics purposes

--- a/watcher/scripts/watchFt.ts
+++ b/watcher/scripts/watchFt.ts
@@ -6,17 +6,39 @@ import { FTSolanaWatcher } from '../src/watchers/FTSolanaWatcher';
 import { FTEVMWatcher } from '../src/watchers/FTEVMWatcher';
 import { Network } from '@wormhole-foundation/sdk-base';
 import { getNetwork } from '@wormhole-foundation/wormhole-monitor-common';
+import { PublicKey } from '@solana/web3.js';
 
 const network = getNetwork();
 async function watchFtSolana(network: Network, fromSlot: number, toSlot: number) {
   const watcher = new FTSolanaWatcher(network);
-  const batchSize = 1000;
 
-  for (let currentSlot = fromSlot; currentSlot <= toSlot; currentSlot += batchSize) {
-    const batchEndSlot = Math.min(currentSlot + batchSize - 1, toSlot);
-    await watcher.getFtMessagesForBlocks(currentSlot, batchEndSlot);
-    console.log(`Processed slots ${currentSlot} to ${batchEndSlot}`);
-  }
+  // for (let currentSlot = fromSlot; currentSlot <= toSlot; currentSlot += batchSize) {
+  //   const batchEndSlot = Math.min(currentSlot + batchSize - 1, toSlot);
+  //   await watcher.getFtMessagesForBlocks(currentSlot, batchEndSlot);
+  //   console.log(`Processed slots ${currentSlot} to ${batchEndSlot}`);
+  // }
+
+  const sigs = [
+    "3gC3F2wvr5p77JXvb7szwihPUNYR79ob68vtspkbaNboULPJV1q55qvAiZSsKiXnNXEeQv3tg492dEa35wbmEPQy",
+    "26Mw7dUekSQUQbPoRF8jiwTURUuvrgRvysASJ8Am7SS2MXjkSYgFMLyQPo5UwHc9fNb8jooa3G2naLyPrS3a5Qcp",
+    "4kXB42Ujb67Hm28XQPuggcTu8qox8RsHANS6UBEnb74WEngSDyhHWfLqq5ftJxnA5fNBaASmhwBrnhQGMhtp7oDM",
+    "5HoSzuRrXEpAyTobdcW9Nvv8qUVUM5rrQqmFrtNdaoZhQs63G8PTryiwU9BYASqvEyyGKLDc1gH9ECPjKggQX61T",
+    "9NYj698U9AzBDdQAC4NxgSoCWEMF3n8X6KzfK2TSq6AKRcfzvu51aQnBas8PP6yobqJA9ip7E3mEgMuunh3ysuW",
+    "3cFvuacoBULB5xFbymQvLnGsVBdnTuf8kLt6DjYL8sb7gZdk3ToPr9ZPmvtMaQGXpHW8oENvHXYDzVunB2gUHcZE",
+    "4YYxJEpcpUokCStcPnbR5GNAYRwnQuHKuLvXuVwDwdct2P3v72VnfbyviQ2TTnLfhGEXDyJF3chVY6bfq3zx7yji",
+    "3LJ2HJtUj7AjajvxFSkKr6skZwt9cB1JtLftBpj619PUG8Yeccow5zFYJcqTYTv6t5aHHxbcrU6mNMA5k2Yoo6zz",
+    "2NqQcdZqGAmjco6Lk5npPegMEa3AZKdx11TDyix352n3GgtPHgFWvMS9p3TkpcgYbC3NWAQvxmf2cgzomsySa1bX",
+    "z9VYybpvDUVJaSvpiKvPh7VfaHCuFYmugoNKSfB6ygXDbLZMnJv5Ccjjv7yY4zxXCLGtKyjD3JVPXGoxuxV9KMW",
+    "21Ecs6yZARuoT4JfgAxaVCkmeNoy39f3a1db6dKfYxX8LJuPivPCFnR5i5yYssaQsDzg43f1NFXc2A8m32ghiGFr",
+    "38HYorUdMRS2ocbHerM5VhxjtF83JYXT5617KMxToZhb8HzCCQ3pWUvp79oVBF5AxQUdMEDRBqSFsCuncgedY36j",
+    "43wWsi2BseU4oMfj6uthnLx9FfQN9EjAy1UbYgz8QsdN3vYy9vCs6t6Gyw5a71Y2Xcaz2PaWVcJvyYTTgG27XPJi",
+    "3gCkjjVw5arxWrKW8RfzM9aaWzy7Dz4RXNhe7uSZAVLeAuCCoyVFoBkw6nxyFQhxKKQkvvDLYVaPbjnMah5bt3WF",
+    "4LCCZkE4oFU1hGfdGdT7SSxquFH6cv5SdWEQgF7MLNnnHjJchv9dRvQtkS6A2gybpfR9N5Vx6PV8k6tzndsdcitw",
+    "2V7g7NNPJqHDy2LKXSh3rkrvFMoSJU5Z3MUEMZ8AEjV7BTv8KALT78p42AoxufdhAkct5xQQY5zH9fKB8dBiqiBj"
+  ];
+
+  await watcher.swapLayerParser.parseTransactions(sigs);
+
 }
 
 async function watchFt(

--- a/watcher/scripts/watchFt.ts
+++ b/watcher/scripts/watchFt.ts
@@ -35,8 +35,8 @@ async function watchFt(
   }
 }
 
-const fromSlot = 300839027;
-const toSlot = 301181384;
+const fromSlot = 301566320;
+const toSlot = 301573280;
 
 const arbitrumFromBlock = 247028328;
 const arbitrumToBlock = 247037682;

--- a/watcher/scripts/watchFt.ts
+++ b/watcher/scripts/watchFt.ts
@@ -41,8 +41,8 @@ const toSlot = 300257525;
 const arbitrumFromBlock = 247028328;
 const arbitrumToBlock = 247037682;
 
-const baseFromBlock = 18820795;
-const baseToBlock = 18958996;
+const baseFromBlock = 22069921;
+const baseToBlock = 22069922;
 
 // watchFt(network, 'Arbitrum', arbitrumFromBlock, arbitrumToBlock).then(() =>
 //   console.log('Done watching ftArbitrum')

--- a/watcher/scripts/watchFt.ts
+++ b/watcher/scripts/watchFt.ts
@@ -11,44 +11,12 @@ import { PublicKey } from '@solana/web3.js';
 const network = getNetwork();
 async function watchFtSolana(network: Network, fromSlot: number, toSlot: number) {
   const watcher = new FTSolanaWatcher(network);
+  const batchSize = 1000;
 
-  // for (let currentSlot = fromSlot; currentSlot <= toSlot; currentSlot += batchSize) {
-  //   const batchEndSlot = Math.min(currentSlot + batchSize - 1, toSlot);
-  //   await watcher.getFtMessagesForBlocks(currentSlot, batchEndSlot);
-  //   console.log(`Processed slots ${currentSlot} to ${batchEndSlot}`);
-  // }
-
-  const sigs = [
-    "3gC3F2wvr5p77JXvb7szwihPUNYR79ob68vtspkbaNboULPJV1q55qvAiZSsKiXnNXEeQv3tg492dEa35wbmEPQy",
-    "26Mw7dUekSQUQbPoRF8jiwTURUuvrgRvysASJ8Am7SS2MXjkSYgFMLyQPo5UwHc9fNb8jooa3G2naLyPrS3a5Qcp",
-    "4kXB42Ujb67Hm28XQPuggcTu8qox8RsHANS6UBEnb74WEngSDyhHWfLqq5ftJxnA5fNBaASmhwBrnhQGMhtp7oDM",
-    "5HoSzuRrXEpAyTobdcW9Nvv8qUVUM5rrQqmFrtNdaoZhQs63G8PTryiwU9BYASqvEyyGKLDc1gH9ECPjKggQX61T",
-    "9NYj698U9AzBDdQAC4NxgSoCWEMF3n8X6KzfK2TSq6AKRcfzvu51aQnBas8PP6yobqJA9ip7E3mEgMuunh3ysuW",
-    "3cFvuacoBULB5xFbymQvLnGsVBdnTuf8kLt6DjYL8sb7gZdk3ToPr9ZPmvtMaQGXpHW8oENvHXYDzVunB2gUHcZE",
-    "4YYxJEpcpUokCStcPnbR5GNAYRwnQuHKuLvXuVwDwdct2P3v72VnfbyviQ2TTnLfhGEXDyJF3chVY6bfq3zx7yji",
-    "3LJ2HJtUj7AjajvxFSkKr6skZwt9cB1JtLftBpj619PUG8Yeccow5zFYJcqTYTv6t5aHHxbcrU6mNMA5k2Yoo6zz",
-    "2NqQcdZqGAmjco6Lk5npPegMEa3AZKdx11TDyix352n3GgtPHgFWvMS9p3TkpcgYbC3NWAQvxmf2cgzomsySa1bX",
-    "z9VYybpvDUVJaSvpiKvPh7VfaHCuFYmugoNKSfB6ygXDbLZMnJv5Ccjjv7yY4zxXCLGtKyjD3JVPXGoxuxV9KMW",
-    "21Ecs6yZARuoT4JfgAxaVCkmeNoy39f3a1db6dKfYxX8LJuPivPCFnR5i5yYssaQsDzg43f1NFXc2A8m32ghiGFr",
-    "38HYorUdMRS2ocbHerM5VhxjtF83JYXT5617KMxToZhb8HzCCQ3pWUvp79oVBF5AxQUdMEDRBqSFsCuncgedY36j",
-    "43wWsi2BseU4oMfj6uthnLx9FfQN9EjAy1UbYgz8QsdN3vYy9vCs6t6Gyw5a71Y2Xcaz2PaWVcJvyYTTgG27XPJi",
-    "3gCkjjVw5arxWrKW8RfzM9aaWzy7Dz4RXNhe7uSZAVLeAuCCoyVFoBkw6nxyFQhxKKQkvvDLYVaPbjnMah5bt3WF",
-    "4LCCZkE4oFU1hGfdGdT7SSxquFH6cv5SdWEQgF7MLNnnHjJchv9dRvQtkS6A2gybpfR9N5Vx6PV8k6tzndsdcitw",
-    "2V7g7NNPJqHDy2LKXSh3rkrvFMoSJU5Z3MUEMZ8AEjV7BTv8KALT78p42AoxufdhAkct5xQQY5zH9fKB8dBiqiBj"
-  ];
-
-  const txs = await watcher.connection?.getTransactions(sigs, {
-    maxSupportedTransactionVersion: 0
-  });
-
-  const slots = txs?.map(tx => tx?.slot)
-
-  if (slots) {
-    for (const slot of slots) {
-      if (!slot) continue;
-      await watcher.getFtMessagesForBlocks(slot, slot);
-      console.log(`Processed slot ${slot}`);
-    }
+  for (let currentSlot = fromSlot; currentSlot <= toSlot; currentSlot += batchSize) {
+    const batchEndSlot = Math.min(currentSlot + batchSize - 1, toSlot);
+    await watcher.getFtMessagesForBlocks(currentSlot, batchEndSlot);
+    console.log(`Processed slots ${currentSlot} to ${batchEndSlot}`);
   }
 }
 
@@ -68,8 +36,8 @@ async function watchFt(
   }
 }
 
-const fromSlot = 301569871;
-const toSlot = 301569872;
+const fromSlot = 301566320;
+const toSlot = 302610552;
 
 const arbitrumFromBlock = 247028328;
 const arbitrumToBlock = 247037682;

--- a/watcher/scripts/watchFt.ts
+++ b/watcher/scripts/watchFt.ts
@@ -37,8 +37,19 @@ async function watchFtSolana(network: Network, fromSlot: number, toSlot: number)
     "2V7g7NNPJqHDy2LKXSh3rkrvFMoSJU5Z3MUEMZ8AEjV7BTv8KALT78p42AoxufdhAkct5xQQY5zH9fKB8dBiqiBj"
   ];
 
-  await watcher.swapLayerParser.parseTransactions(sigs);
+  const txs = await watcher.connection?.getTransactions(sigs, {
+    maxSupportedTransactionVersion: 0
+  });
 
+  const slots = txs?.map(tx => tx?.slot)
+
+  if (slots) {
+    for (const slot of slots) {
+      if (!slot) continue;
+      await watcher.getFtMessagesForBlocks(slot, slot);
+      console.log(`Processed slot ${slot}`);
+    }
+  }
 }
 
 async function watchFt(

--- a/watcher/scripts/watchFt.ts
+++ b/watcher/scripts/watchFt.ts
@@ -35,8 +35,8 @@ async function watchFt(
   }
 }
 
-const fromSlot = 301566320;
-const toSlot = 301573280;
+const fromSlot = 301569871;
+const toSlot = 301569872;
 
 const arbitrumFromBlock = 247028328;
 const arbitrumToBlock = 247037682;

--- a/watcher/scripts/watchFt.ts
+++ b/watcher/scripts/watchFt.ts
@@ -35,14 +35,14 @@ async function watchFt(
   }
 }
 
-const fromSlot = 300257524;
-const toSlot = 300257525;
+const fromSlot = 300839027;
+const toSlot = 301181384;
 
 const arbitrumFromBlock = 247028328;
 const arbitrumToBlock = 247037682;
 
-const baseFromBlock = 22069921;
-const baseToBlock = 22069922;
+const baseFromBlock = 22069582;
+const baseToBlock = 22329636;
 
 // watchFt(network, 'Arbitrum', arbitrumFromBlock, arbitrumToBlock).then(() =>
 //   console.log('Done watching ftArbitrum')

--- a/watcher/scripts/watchFt.ts
+++ b/watcher/scripts/watchFt.ts
@@ -35,8 +35,8 @@ async function watchFt(
   }
 }
 
-const fromSlot = 321556219;
-const toSlot = 321807831;
+const fromSlot = 300257524;
+const toSlot = 300257525;
 
 const arbitrumFromBlock = 247028328;
 const arbitrumToBlock = 247037682;
@@ -44,12 +44,12 @@ const arbitrumToBlock = 247037682;
 const baseFromBlock = 18820795;
 const baseToBlock = 18958996;
 
-watchFt(network, 'Arbitrum', arbitrumFromBlock, arbitrumToBlock).then(() =>
-  console.log('Done watching ftArbitrum')
-);
+// watchFt(network, 'Arbitrum', arbitrumFromBlock, arbitrumToBlock).then(() =>
+//   console.log('Done watching ftArbitrum')
+// );
 
-watchFt(network, 'Base', baseFromBlock, baseToBlock).then(() =>
-  console.log('Done watching ftBase')
-);
+// watchFt(network, 'Base', baseFromBlock, baseToBlock).then(() =>
+//   console.log('Done watching ftBase')
+// );
 
 watchFtSolana(network, fromSlot, toSlot).then(() => console.log('Done watching ftSolana'));

--- a/watcher/src/fastTransfer/consts.ts
+++ b/watcher/src/fastTransfer/consts.ts
@@ -47,7 +47,7 @@ export const FAST_TRANSFER_CONTRACTS: FastTransferContractAddresses = {
       TokenRouter: '28topqjtJzMnPaGFmmZk68tzGmj9W9aMntaEK3QkgtRe',
       USDCMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
       // TODO: uncomment this when SwapLayer is deployed on Solana Mainnet
-      // SwapLayer: '9Zv8ajzFjacRoYCgCPus4hq3pYjpNa9KkTFQ1sHa1h3d',
+      SwapLayer: '9Zv8ajzFjacRoYCgCPus4hq3pYjpNa9KkTFQ1sHa1h3d',
     },
     Arbitrum: {
       TokenRouter: '0x70287c79ee41C5D1df8259Cd68Ba0890cd389c47',

--- a/watcher/src/fastTransfer/consts.ts
+++ b/watcher/src/fastTransfer/consts.ts
@@ -46,18 +46,17 @@ export const FAST_TRANSFER_CONTRACTS: FastTransferContractAddresses = {
       MatchingEngine: 'HtkeCDdYY4i9ncAxXKjYTx8Uu3WM8JbtiLRYjtHwaVXb',
       TokenRouter: '28topqjtJzMnPaGFmmZk68tzGmj9W9aMntaEK3QkgtRe',
       USDCMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-      // TODO: uncomment this when SwapLayer is deployed on Solana Mainnet
       SwapLayer: '9Zv8ajzFjacRoYCgCPus4hq3pYjpNa9KkTFQ1sHa1h3d',
     },
     Arbitrum: {
       TokenRouter: '0x70287c79ee41C5D1df8259Cd68Ba0890cd389c47',
       CircleBridge: '0x19330d10D9Cc8751218eaf51E8885D058642E08A',
-      SwapLayer: '0x4dE319b7492E791cDe47FDf12c922cF568441C43',
+      SwapLayer: '0x201Ad7e4f00831A25b2eD9f85AcaEF4123D625ae',
     },
     Base: {
       TokenRouter: '0x70287c79ee41C5D1df8259Cd68Ba0890cd389c47',
       CircleBridge: '0x1682Ae6375C4E4A97e4B583BC394c861A46D8962',
-      SwapLayer: '0x2Ab7BeEF955826054d03419Ee2122445Ca677eb2',
+      SwapLayer: '0xdacA614bE8e0C15Bf362b69d28ed65Ead710Cbfa',
     },
   },
   Testnet: {

--- a/watcher/src/fastTransfer/swapLayer/solParser.ts
+++ b/watcher/src/fastTransfer/swapLayer/solParser.ts
@@ -244,10 +244,6 @@ export class SwapLayerParser {
         ? getTokenBalanceChange(transaction, recipient.toBase58(), this.USDC_MINT.toBase58())
         : 0n;
 
-    console.log(`Instruction Name: ${instructionName}`);
-    console.log(`Recipient Account Key: ${recipient.toBase58()}`);
-    console.log(`Fee Recipient Account Key: ${this.getAccountKey(transaction, ix, 6)?.toBase58()}`);
-
     const relayingFee = instructionName === 'complete_transfer_relay'
       ? getTokenBalanceChange(transaction, this.getAccountKey(transaction, ix, 6)?.toBase58() || '', this.USDC_MINT.toBase58()) : 0n;
 

--- a/watcher/src/fastTransfer/swapLayer/solParser.ts
+++ b/watcher/src/fastTransfer/swapLayer/solParser.ts
@@ -190,7 +190,7 @@ export class SwapLayerParser {
       fill_id: accounts[ix.accountKeyIndexes[fillAccountIndex]].pubkey.toBase58(),
       output_token: outputToken,
       recipient: recipient,
-      redeem_time: blockTimeToDate(blockTime),
+      redeem_time: instructionName === 'complete_swap_payload' ? null : blockTimeToDate(blockTime),
       output_amount: tokenBalance,
       staged_inbound: stagedInbound,
       tx_hash: sig,
@@ -246,10 +246,10 @@ export class SwapLayerParser {
 
     console.log(`Instruction Name: ${instructionName}`);
     console.log(`Recipient Account Key: ${recipient.toBase58()}`);
+    console.log(`Fee Recipient Account Key: ${this.getAccountKey(transaction, ix, 6)?.toBase58()}`);
 
     const relayingFee = instructionName === 'complete_transfer_relay'
-      ? 0n
-      : getTokenBalanceChange(transaction, this.getAccountKey(transaction, ix, 6)?.toBase58() || '', this.USDC_MINT.toBase58());
+      ? getTokenBalanceChange(transaction, this.getAccountKey(transaction, ix, 6)?.toBase58() || '', this.USDC_MINT.toBase58()) : 0n;
 
     const fillAccount = this.getAccountKey(transaction, ix, fillAccountIndex);
     if (!fillAccount) {
@@ -262,7 +262,7 @@ export class SwapLayerParser {
       relaying_fee: relayingFee,
       fill_id: fillAccount.toBase58(),
       output_token: this.USDC_MINT.toBase58(),
-      redeem_time: blockTimeToDate(transaction.blockTime),
+      redeem_time: instructionName === 'complete_transfer_payload' ? null : blockTimeToDate(transaction.blockTime),
       output_amount: tokenBalance,
       staged_inbound:
         instructionName === 'complete_transfer_payload'

--- a/watcher/src/fastTransfer/types.ts
+++ b/watcher/src/fastTransfer/types.ts
@@ -151,7 +151,7 @@ export type TransferCompletion = {
   output_token: string;
   output_amount: bigint;
   relaying_fee: bigint;
-  redeem_time: Date;
+  redeem_time: Date | null; // this needs to be null as `complete_{transfer, swap}_payload` should not mean that it is redeemed
   fill_id: string;
   // on Solana Swap Layer, this acts as a link between complete_{transfer, swap}_payload and release_inbound
   staged_inbound?: string;

--- a/watcher/src/idls/matching_engine.json
+++ b/watcher/src/idls/matching_engine.json
@@ -1,6 +1,5 @@
 {
   "address": "MatchingEngine11111111111111111111111111111",
-  "name": "matching_engine",
   "metadata": {
     "name": "matching_engine",
     "version": "0.0.0",
@@ -56,11 +55,8 @@
         },
         {
           "name": "beneficiary",
-          "docs": ["was no auction) or the owner of the initial offer token account."],
+          "docs": ["[Auction::prepared_by]."],
           "writable": true
-        },
-        {
-          "name": "beneficiary_token"
         },
         {
           "name": "system_program"
@@ -372,6 +368,12 @@
         },
         {
           "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -572,6 +574,7 @@
             },
             {
               "name": "executor_token",
+              "docs": ["Must be a token account, whose mint is [common::USDC_MINT]."],
               "writable": true
             },
             {
@@ -580,7 +583,6 @@
             },
             {
               "name": "initial_participant",
-              "docs": ["does not exist anymore, we will attempt to perform this check."],
               "writable": true
             }
           ]
@@ -688,6 +690,12 @@
               ]
             }
           ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -751,6 +759,7 @@
             },
             {
               "name": "executor_token",
+              "docs": ["Must be a token account, whose mint is [common::USDC_MINT]."],
               "writable": true
             },
             {
@@ -759,7 +768,6 @@
             },
             {
               "name": "initial_participant",
-              "docs": ["does not exist anymore, we will attempt to perform this check."],
               "writable": true
             }
           ]
@@ -776,10 +784,11 @@
           "writable": true
         },
         {
-          "name": "best_offer_participant",
+          "name": "reserve_beneficiary",
           "docs": [
             "When the reserved sequence account was created, the beneficiary was set to the best offer",
-            "token's owner. This account will receive the lamports from the reserved sequence account.",
+            "token's owner if it existed (and if not, to whomever executed the reserve fast fill sequence",
+            "instruction). This account will receive the lamports from the reserved sequence account.",
             ""
           ],
           "writable": true
@@ -871,6 +880,12 @@
         },
         {
           "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
@@ -1098,6 +1113,12 @@
         },
         {
           "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
@@ -1184,6 +1205,15 @@
         {
           "name": "prepared_custody_token",
           "writable": true
+        },
+        {
+          "name": "base_fee_token",
+          "docs": [
+            "This token account will be the one that collects the base fee only if an auction's order",
+            "was executed late. Otherwise, the protocol's fee recipient token account will be used for",
+            "non-existent auctions and the best offer token account will be used for orders executed on",
+            "time."
+          ]
         },
         {
           "name": "usdc",
@@ -1320,6 +1350,12 @@
         },
         {
           "name": "epoch_schedule"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
@@ -1418,26 +1454,26 @@
               "writable": true
             },
             {
+              "name": "auction",
+              "docs": [
+                "must have been created by this point. Otherwise the auction account must reflect a completed",
+                "auction."
+              ],
+              "writable": true
+            },
+            {
               "name": "system_program"
             }
-          ]
-        },
-        {
-          "name": "auction",
-          "docs": [
-            "must have been created by this point. Otherwise the auction account must reflect a completed",
-            "auction."
           ]
         },
         {
           "name": "auction_config"
         },
         {
-          "name": "best_offer_token",
-          "docs": [
-            "Best offer token account, whose owner will be the beneficiary of the reserved fast fill",
-            "sequence account when it is closed."
-          ]
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -1454,6 +1490,15 @@
         "order response should call this instruction to reserve the fast fill's sequence number.",
         "This sequence number is warehoused in the `ReservedFastFillSequence` account and will be",
         "closed when the funds are finally settled.",
+        "",
+        "NOTE: This instruction is expected to be in the same transaction as the one that executes",
+        "the prepare order response instruction. If it is not, there is a risk that after preparing",
+        "the order response that someone starts an auction. This scenario risks the preparer's rent",
+        "that he paid because the winning auction participant can take his lamports when he calls",
+        "settle auction complete. Although this is an unlikely scenario, it is possible if there is",
+        "no deadline specified to start the auction and no participants use the fast VAA to start an",
+        "auction until the finalized VAA exists (which guarantees that the funds have finalized on",
+        "the source network).",
         "",
         "# Arguments",
         "",
@@ -1524,6 +1569,14 @@
               "writable": true
             },
             {
+              "name": "auction",
+              "docs": [
+                "must have been created by this point. Otherwise the auction account must reflect a completed",
+                "auction."
+              ],
+              "writable": true
+            },
+            {
               "name": "system_program"
             }
           ]
@@ -1537,11 +1590,10 @@
           ]
         },
         {
-          "name": "auction",
-          "docs": [
-            "must have been created by this point. Otherwise the auction account must reflect a completed",
-            "auction."
-          ]
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -1595,16 +1647,17 @@
       "discriminator": [84, 39, 0, 132, 21, 101, 222, 137],
       "accounts": [
         {
-          "name": "executor",
-          "docs": [
-            "we will always reward the owner of the executor token account with the lamports from the",
-            "prepared order response and its custody token account when we close these accounts. This",
-            "means we disregard the `prepared_by` field in the prepared order response."
-          ],
+          "name": "beneficiary",
+          "docs": ["finalized VAA."],
           "writable": true
         },
         {
-          "name": "executor_token",
+          "name": "base_fee_token",
+          "docs": [
+            "This token account will receive the base fee only if there was a penalty when executing the",
+            "order. If it does not exist when there is a penalty, this instruction handler will revert.",
+            ""
+          ],
           "writable": true
         },
         {
@@ -1613,7 +1666,8 @@
             "Destination token account, which the redeemer may not own. But because the redeemer is a",
             "signer and is the one encoded in the Deposit Fill message, he may have the tokens be sent",
             "to any account he chooses (this one).",
-            ""
+            "",
+            "of the tokens to the base fee token account."
           ],
           "writable": true
         },
@@ -1631,6 +1685,12 @@
         },
         {
           "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -1797,6 +1857,12 @@
               ]
             }
           ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -1857,7 +1923,10 @@
         },
         {
           "name": "auction",
-          "docs": ["There should be no account data here because an auction was never created."],
+          "docs": [
+            "This account will have been created using the reserve fast fill sequence (no auction)",
+            "instruction. We need to make sure that this account has not been used in an auction."
+          ],
           "writable": true
         },
         {
@@ -1952,8 +2021,8 @@
       "name": "update_auction_parameters",
       "docs": [
         "This instruction is used to enact an existing auction update proposal. It can only be",
-        "executed after the `slot_enact_delay` has passed. This instruction can only be called by",
-        "the `owner` of the proposal.",
+        "executed after the `slot_enact_delay` has passed. This instruction can only be called by the",
+        "`owner`.",
         "",
         "# Arguments",
         "",
@@ -1989,6 +2058,12 @@
         },
         {
           "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -2480,7 +2555,7 @@
     },
     {
       "code": 7065,
-      "name": "AccountNotAuction"
+      "name": "NoAuction"
     },
     {
       "code": 7066,
@@ -2517,6 +2592,18 @@
     {
       "code": 7080,
       "name": "ReservedSequenceMismatch"
+    },
+    {
+      "code": 7082,
+      "name": "AuctionAlreadySettled"
+    },
+    {
+      "code": 7084,
+      "name": "InvalidBaseFeeToken"
+    },
+    {
+      "code": 7086,
+      "name": "BaseFeeTokenRequired"
     },
     {
       "code": 7280,
@@ -2600,6 +2687,11 @@
                 "name": "AuctionStatus"
               }
             }
+          },
+          {
+            "name": "prepared_by",
+            "docs": ["The fee payer when placing the initial offer."],
+            "type": "pubkey"
           },
           {
             "name": "info",
@@ -2894,26 +2986,40 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "auction",
+            "name": "fast_vaa_hash",
             "docs": ["The pubkey of the auction that was settled."],
-            "type": "pubkey"
+            "type": {
+              "array": ["u8", 32]
+            }
           },
           {
             "name": "best_offer_token",
             "docs": [
-              "If there was an active auction, this pubkey is the best offer token that was paid back."
+              "If there was an active auction, this field will have the pubkey of the best offer token that",
+              "was paid back and its balance after repayment."
             ],
             "type": {
-              "option": "pubkey"
+              "option": {
+                "defined": {
+                  "name": "SettledTokenAccountInfo"
+                }
+              }
             }
           },
           {
-            "name": "token_balance_after",
+            "name": "base_fee_token",
             "docs": [
-              "Token account's new balance. If there was no auction, this balance will be of the fee",
-              "recipient token account."
+              "Depending on whether there was an active auction, this field will have the pubkey of the",
+              "base fee token account (if there was an auction) or fee recipient token (if there was no",
+              "auction)."
             ],
-            "type": "u64"
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "SettledTokenAccountInfo"
+                }
+              }
+            }
           },
           {
             "name": "with_execute",
@@ -2983,8 +3089,10 @@
             "type": "u32"
           },
           {
-            "name": "auction",
-            "type": "pubkey"
+            "name": "fast_vaa_hash",
+            "type": {
+              "array": ["u8", 32]
+            }
           },
           {
             "name": "vaa",
@@ -3030,7 +3138,9 @@
           },
           {
             "name": "max_offer_price_allowed",
-            "type": "u64"
+            "type": {
+              "option": "u64"
+            }
           }
         ]
       }
@@ -3226,7 +3336,11 @@
           },
           {
             "name": "fast_fill",
-            "type": "pubkey"
+            "type": {
+              "defined": {
+                "name": "FastFillSeeds"
+              }
+            }
           }
         ]
       }
@@ -3276,7 +3390,7 @@
             }
           },
           {
-            "name": "fast_fill_seeds",
+            "name": "fast_fill",
             "type": {
               "defined": {
                 "name": "FastFillSeeds"
@@ -3411,8 +3525,10 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "auction",
-            "type": "pubkey"
+            "name": "fast_vaa_hash",
+            "type": {
+              "array": ["u8", 32]
+            }
           },
           {
             "name": "vaa",
@@ -3480,6 +3596,10 @@
         "fields": [
           {
             "name": "prepared_by",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_fee_token",
             "type": "pubkey"
           },
           {
@@ -3706,6 +3826,22 @@
                 "name": "EndpointInfo"
               }
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SettledTokenAccountInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": "pubkey"
+          },
+          {
+            "name": "balance_after",
+            "type": "u64"
           }
         ]
       }

--- a/watcher/src/idls/swap_layer.json
+++ b/watcher/src/idls/swap_layer.json
@@ -20,7 +20,16 @@
         "* `ctx` - The context for adding the peer.",
         "* `args` - The arguments for adding the peer."
       ],
-      "discriminator": [165, 134, 139, 216, 120, 149, 247, 255],
+      "discriminator": [
+        165,
+        134,
+        139,
+        216,
+        120,
+        149,
+        247,
+        255
+      ],
       "accounts": [
         {
           "name": "payer",
@@ -75,7 +84,16 @@
         "",
         "* `ctx` - The context for canceling the ownership transfer request."
       ],
-      "discriminator": [167, 61, 9, 35, 192, 41, 64, 178],
+      "discriminator": [
+        167,
+        61,
+        9,
+        35,
+        192,
+        41,
+        64,
+        178
+      ],
       "accounts": [
         {
           "name": "admin",
@@ -104,11 +122,22 @@
         "",
         "* `ctx` - The context for closing the staged outbound."
       ],
-      "discriminator": [67, 69, 31, 1, 231, 243, 10, 12],
+      "discriminator": [
+        67,
+        69,
+        31,
+        1,
+        231,
+        243,
+        10,
+        12
+      ],
       "accounts": [
         {
           "name": "sender",
-          "docs": ["This signer must be the same one encoded in the prepared order."],
+          "docs": [
+            "This signer must be the same one encoded in the prepared order."
+          ],
           "writable": true,
           "signer": true
         },
@@ -126,17 +155,23 @@
         },
         {
           "name": "staged_outbound",
-          "docs": ["Staging for outbound transfer. This instruction closes this account."],
+          "docs": [
+            "Staging for outbound transfer. This instruction closes this account."
+          ],
           "writable": true
         },
         {
           "name": "staged_custody_token",
-          "docs": ["This custody token account will be closed by the end of the instruction."],
+          "docs": [
+            "This custody token account will be closed by the end of the instruction."
+          ],
           "writable": true
         },
         {
           "name": "sender_token",
-          "docs": ["already check that the sender is the same as the prepared_by account."],
+          "docs": [
+            "already check that the sender is the same as the prepared_by account."
+          ],
           "writable": true,
           "optional": true
         },
@@ -159,7 +194,16 @@
         "* `ctx` - The context for completing the swap.",
         "* `instruction_data` - The instruction data for completing the swap."
       ],
-      "discriminator": [40, 166, 72, 2, 172, 18, 32, 75],
+      "discriminator": [
+        40,
+        166,
+        72,
+        2,
+        172,
+        18,
+        32,
+        75
+      ],
       "accounts": [
         {
           "name": "complete_swap",
@@ -217,7 +261,9 @@
               "name": "src_swap_token",
               "docs": [
                 "Temporary swap token account to receive USDC from the prepared fill. This account will be",
-                "closed at the end of this instruction."
+                "closed at the end of this instruction.",
+                "",
+                "NOTE: This ATA must already be created."
               ],
               "writable": true
             },
@@ -225,13 +271,17 @@
               "name": "dst_swap_token",
               "docs": [
                 "Temporary swap token account to receive destination mint after the swap. This account will",
-                "be closed at the end of this instruction."
+                "be closed at the end of this instruction.",
+                "",
+                "NOTE: This ATA must already be created."
               ],
               "writable": true
             },
             {
               "name": "fee_recipient_token",
-              "docs": ["token account."],
+              "docs": [
+                "token account."
+              ],
               "writable": true
             },
             {
@@ -252,9 +302,6 @@
               "name": "dst_token_program"
             },
             {
-              "name": "associated_token_program"
-            },
-            {
               "name": "system_program"
             }
           ]
@@ -273,7 +320,9 @@
         },
         {
           "name": "recipient",
-          "docs": ["account must be encoded in the prepared fill."],
+          "docs": [
+            "account must be encoded in the prepared fill."
+          ],
           "writable": true
         }
       ],
@@ -294,7 +343,16 @@
         "* `ctx` - The context for completing the swap.",
         "* `instruction_data` - The instruction data for completing the swap."
       ],
-      "discriminator": [82, 168, 4, 109, 220, 211, 26, 20],
+      "discriminator": [
+        82,
+        168,
+        4,
+        109,
+        220,
+        211,
+        26,
+        20
+      ],
       "accounts": [
         {
           "name": "payer",
@@ -350,7 +408,9 @@
           "name": "src_swap_token",
           "docs": [
             "Temporary swap token account to receive USDC from the prepared fill. This account will be",
-            "closed at the end of this instruction."
+            "closed at the end of this instruction.",
+            "",
+            "NOTE: This ATA must already be created."
           ],
           "writable": true
         },
@@ -358,13 +418,17 @@
           "name": "dst_swap_token",
           "docs": [
             "Temporary swap token account to receive destination mint after the swap. This account will",
-            "be closed at the end of this instruction."
+            "be closed at the end of this instruction.",
+            "",
+            "NOTE: This ATA must already be created."
           ],
           "writable": true
         },
         {
           "name": "fee_recipient_token",
-          "docs": ["token account."],
+          "docs": [
+            "token account."
+          ],
           "writable": true
         },
         {
@@ -383,9 +447,6 @@
         },
         {
           "name": "dst_token_program"
-        },
-        {
-          "name": "associated_token_program"
         },
         {
           "name": "system_program"
@@ -411,7 +472,16 @@
         "* `ctx` - The context for completing the swap.",
         "* `instruction_data` - The instruction data for completing the swap."
       ],
-      "discriminator": [108, 241, 108, 248, 142, 211, 140, 252],
+      "discriminator": [
+        108,
+        241,
+        108,
+        248,
+        142,
+        211,
+        140,
+        252
+      ],
       "accounts": [
         {
           "name": "complete_swap",
@@ -469,7 +539,9 @@
               "name": "src_swap_token",
               "docs": [
                 "Temporary swap token account to receive USDC from the prepared fill. This account will be",
-                "closed at the end of this instruction."
+                "closed at the end of this instruction.",
+                "",
+                "NOTE: This ATA must already be created."
               ],
               "writable": true
             },
@@ -477,13 +549,17 @@
               "name": "dst_swap_token",
               "docs": [
                 "Temporary swap token account to receive destination mint after the swap. This account will",
-                "be closed at the end of this instruction."
+                "be closed at the end of this instruction.",
+                "",
+                "NOTE: This ATA must already be created."
               ],
               "writable": true
             },
             {
               "name": "fee_recipient_token",
-              "docs": ["token account."],
+              "docs": [
+                "token account."
+              ],
               "writable": true
             },
             {
@@ -504,9 +580,6 @@
               "name": "dst_token_program"
             },
             {
-              "name": "associated_token_program"
-            },
-            {
               "name": "system_program"
             }
           ]
@@ -525,7 +598,9 @@
         },
         {
           "name": "recipient",
-          "docs": ["account must be encoded in the prepared fill."],
+          "docs": [
+            "account must be encoded in the prepared fill."
+          ],
           "writable": true
         }
       ],
@@ -545,8 +620,26 @@
         "",
         "* `ctx` - The context for completing the direct transfer."
       ],
-      "discriminator": [233, 87, 221, 31, 40, 175, 108, 183],
+      "discriminator": [
+        233,
+        87,
+        221,
+        31,
+        40,
+        175,
+        108,
+        183
+      ],
       "accounts": [
+        {
+          "name": "redeemer",
+          "docs": [
+            "This redeemer is used to check against the recipient. If the redeemer is the same as the",
+            "recipient, he is free to redeem his tokens directly as USDC even if swap instructions are",
+            "encoded."
+          ],
+          "signer": true
+        },
         {
           "name": "consume_swap_layer_fill",
           "accounts": [
@@ -621,11 +714,29 @@
         "",
         "* `ctx` - The context for completing the payload transfer."
       ],
-      "discriminator": [14, 221, 53, 29, 211, 192, 38, 178],
+      "discriminator": [
+        14,
+        221,
+        53,
+        29,
+        211,
+        192,
+        38,
+        178
+      ],
       "accounts": [
         {
           "name": "payer",
           "writable": true,
+          "signer": true
+        },
+        {
+          "name": "redeemer",
+          "docs": [
+            "This redeemer is used to check against the recipient. If the redeemer is the same as the",
+            "recipient, he is free to redeem his tokens directly as USDC even if swap instructions are",
+            "encoded."
+          ],
           "signer": true
         },
         {
@@ -716,7 +827,16 @@
         "",
         "* `ctx` - The context for completing the transfer relay."
       ],
-      "discriminator": [201, 115, 7, 40, 86, 54, 76, 213],
+      "discriminator": [
+        201,
+        115,
+        7,
+        40,
+        86,
+        54,
+        76,
+        213
+      ],
       "accounts": [
         {
           "name": "payer",
@@ -724,6 +844,15 @@
             "The payer of the transaction. This could either be the recipient or a relayer."
           ],
           "writable": true,
+          "signer": true
+        },
+        {
+          "name": "redeemer",
+          "docs": [
+            "This redeemer is used to check against the recipient. If the redeemer is the same as the",
+            "recipient, he is free to redeem his tokens directly as USDC even if swap instructions are",
+            "encoded."
+          ],
           "signer": true
         },
         {
@@ -822,11 +951,23 @@
         "",
         "* `ctx` - The context for confirming the ownership transfer request."
       ],
-      "discriminator": [118, 148, 109, 68, 201, 30, 139, 53],
+      "discriminator": [
+        118,
+        148,
+        109,
+        68,
+        201,
+        30,
+        139,
+        53
+      ],
       "accounts": [
         {
           "name": "pending_owner",
-          "docs": ["Must be the pending owner of the program set in the [`Custodian`]", "account."],
+          "docs": [
+            "Must be the pending owner of the program set in the [`Custodian`]",
+            "account."
+          ],
           "signer": true
         },
         {
@@ -849,11 +990,22 @@
         "",
         "* `ctx` - The context for the initialization."
       ],
-      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
       "accounts": [
         {
           "name": "owner",
-          "docs": ["Owner of the program, who presumably deployed this program."],
+          "docs": [
+            "Owner of the program, who presumably deployed this program."
+          ],
           "writable": true,
           "signer": true
         },
@@ -903,7 +1055,16 @@
         "* `ctx` - The context for initiating the swap.",
         "* `instruction_data` - The instruction data for initiating the swap."
       ],
-      "discriminator": [92, 141, 83, 248, 20, 79, 30, 13],
+      "discriminator": [
+        92,
+        141,
+        83,
+        248,
+        20,
+        79,
+        30,
+        13
+      ],
       "accounts": [
         {
           "name": "payer",
@@ -962,7 +1123,9 @@
           "name": "src_swap_token",
           "docs": [
             "Temporary swap token account to receive source mint from the staged custody token. This",
-            "account will be closed at the end of this instruction."
+            "account will be closed at the end of this instruction.",
+            "",
+            "NOTE: This ATA must already be created."
           ],
           "writable": true
         },
@@ -970,13 +1133,17 @@
           "name": "dst_swap_token",
           "docs": [
             "Temporary swap token account to receive destination mint after the swap. This account will",
-            "be closed at the end of this instruction."
+            "be closed at the end of this instruction.",
+            "",
+            "NOTE: This ATA must already be created."
           ],
           "writable": true
         },
         {
           "name": "src_mint",
-          "docs": ["This account must be verified as the source mint for the swap."]
+          "docs": [
+            "This account must be verified as the source mint for the swap."
+          ]
         },
         {
           "name": "usdc",
@@ -998,9 +1165,6 @@
         },
         {
           "name": "token_router_program"
-        },
-        {
-          "name": "associated_token_program"
         },
         {
           "name": "src_token_program"
@@ -1028,7 +1192,16 @@
         "",
         "* `ctx` - The context for initiating the transfer."
       ],
-      "discriminator": [128, 229, 77, 5, 65, 234, 228, 75],
+      "discriminator": [
+        128,
+        229,
+        77,
+        5,
+        65,
+        234,
+        228,
+        75
+      ],
       "accounts": [
         {
           "name": "payer",
@@ -1059,7 +1232,9 @@
         },
         {
           "name": "staged_custody_token",
-          "docs": ["This custody token account will be closed by the end of the instruction."],
+          "docs": [
+            "This custody token account will be closed by the end of the instruction."
+          ],
           "writable": true
         },
         {
@@ -1117,11 +1292,22 @@
         "",
         "* `ctx` - The context for releasing the inbound transfer."
       ],
-      "discriminator": [116, 169, 86, 154, 87, 2, 36, 20],
+      "discriminator": [
+        116,
+        169,
+        86,
+        154,
+        87,
+        2,
+        36,
+        20
+      ],
       "accounts": [
         {
           "name": "recipient",
-          "docs": ["This signer must be the same one encoded in the staged transfer."],
+          "docs": [
+            "This signer must be the same one encoded in the staged transfer."
+          ],
           "signer": true
         },
         {
@@ -1173,7 +1359,16 @@
         "* `ctx` - The context for staging the outbound transfer.",
         "* `args` - The arguments for staging the outbound transfer."
       ],
-      "discriminator": [69, 205, 153, 23, 99, 248, 131, 98],
+      "discriminator": [
+        69,
+        205,
+        153,
+        23,
+        99,
+        248,
+        131,
+        98
+      ],
       "accounts": [
         {
           "name": "payer",
@@ -1236,7 +1431,9 @@
         },
         {
           "name": "src_mint",
-          "docs": ["Mint can either be USDC or whichever mint is used to swap into USDC."]
+          "docs": [
+            "Mint can either be USDC or whichever mint is used to swap into USDC."
+          ]
         },
         {
           "name": "src_token_program"
@@ -1272,7 +1469,16 @@
         "",
         "* `ctx` - The context for submitting the ownership transfer request."
       ],
-      "discriminator": [215, 13, 88, 199, 48, 195, 19, 225],
+      "discriminator": [
+        215,
+        13,
+        88,
+        199,
+        48,
+        195,
+        19,
+        225
+      ],
       "accounts": [
         {
           "name": "admin",
@@ -1289,7 +1495,10 @@
         },
         {
           "name": "new_owner",
-          "docs": ["New Owner.", ""]
+          "docs": [
+            "New Owner.",
+            ""
+          ]
         }
       ],
       "args": []
@@ -1307,7 +1516,16 @@
         "",
         "* `ctx` - The context for updating the fee recipient."
       ],
-      "discriminator": [249, 0, 198, 35, 183, 123, 57, 188],
+      "discriminator": [
+        249,
+        0,
+        198,
+        35,
+        183,
+        123,
+        57,
+        188
+      ],
       "accounts": [
         {
           "name": "admin",
@@ -1327,7 +1545,10 @@
         },
         {
           "name": "new_fee_recipient",
-          "docs": ["New Fee Recipient.", ""]
+          "docs": [
+            "New Fee Recipient.",
+            ""
+          ]
         }
       ],
       "args": []
@@ -1341,7 +1562,16 @@
         "",
         "* `ctx` - The context for updating the fee updater."
       ],
-      "discriminator": [151, 53, 252, 33, 160, 246, 212, 86],
+      "discriminator": [
+        151,
+        53,
+        252,
+        33,
+        160,
+        246,
+        212,
+        86
+      ],
       "accounts": [
         {
           "name": "admin",
@@ -1358,7 +1588,10 @@
         },
         {
           "name": "new_fee_updater",
-          "docs": ["New Fee Updater.", ""]
+          "docs": [
+            "New Fee Updater.",
+            ""
+          ]
         }
       ],
       "args": []
@@ -1375,7 +1608,16 @@
         "",
         "* `ctx` - The context for updating the owner assistant."
       ],
-      "discriminator": [153, 83, 175, 53, 168, 34, 131, 22],
+      "discriminator": [
+        153,
+        83,
+        175,
+        53,
+        168,
+        34,
+        131,
+        22
+      ],
       "accounts": [
         {
           "name": "admin",
@@ -1392,7 +1634,10 @@
         },
         {
           "name": "new_owner_assistant",
-          "docs": ["New Assistant.", ""]
+          "docs": [
+            "New Assistant.",
+            ""
+          ]
         }
       ],
       "args": []
@@ -1408,7 +1653,16 @@
         "* `ctx` - The context for updating the peer.",
         "* `args` - The arguments for updating the peer."
       ],
-      "discriminator": [34, 240, 139, 39, 182, 104, 150, 232],
+      "discriminator": [
+        34,
+        240,
+        139,
+        39,
+        182,
+        104,
+        150,
+        232
+      ],
       "accounts": [
         {
           "name": "admin",
@@ -1453,7 +1707,16 @@
         "* `ctx` - The context for updating the relay parameters.",
         "* `args` - The arguments for updating the relay parameters."
       ],
-      "discriminator": [14, 75, 26, 86, 220, 131, 198, 205],
+      "discriminator": [
+        14,
+        75,
+        26,
+        86,
+        220,
+        131,
+        198,
+        205
+      ],
       "accounts": [
         {
           "name": "fee_updater",
@@ -1492,23 +1755,68 @@
   "accounts": [
     {
       "name": "Custodian",
-      "discriminator": [132, 228, 139, 184, 112, 228, 108, 240]
+      "discriminator": [
+        132,
+        228,
+        139,
+        184,
+        112,
+        228,
+        108,
+        240
+      ]
     },
     {
       "name": "Peer",
-      "discriminator": [50, 8, 19, 55, 40, 253, 37, 58]
+      "discriminator": [
+        50,
+        8,
+        19,
+        55,
+        40,
+        253,
+        37,
+        58
+      ]
     },
     {
       "name": "PreparedFill",
-      "discriminator": [202, 241, 65, 186, 110, 235, 238, 80]
+      "discriminator": [
+        202,
+        241,
+        65,
+        186,
+        110,
+        235,
+        238,
+        80
+      ]
     },
     {
       "name": "StagedInbound",
-      "discriminator": [65, 230, 81, 119, 138, 87, 231, 76]
+      "discriminator": [
+        65,
+        230,
+        81,
+        119,
+        138,
+        87,
+        231,
+        76
+      ]
     },
     {
       "name": "StagedOutbound",
-      "discriminator": [88, 31, 179, 29, 184, 53, 196, 180]
+      "discriminator": [
+        88,
+        31,
+        179,
+        29,
+        184,
+        53,
+        196,
+        180
+      ]
     }
   ],
   "errors": [
@@ -1629,6 +1937,10 @@
       "name": "ImmutableProgram"
     },
     {
+      "code": 6282,
+      "name": "InvalidRedeemer"
+    },
+    {
       "code": 6512,
       "name": "InvalidBaseFee"
     },
@@ -1673,12 +1985,20 @@
       "name": "RelayingFeeExceedsMinAmountOut"
     },
     {
+      "code": 6609,
+      "name": "ZeroAmountIn"
+    },
+    {
       "code": 6610,
       "name": "ZeroMinAmountOut"
     },
     {
       "code": 6612,
       "name": "DelegatedAmountMismatch"
+    },
+    {
+      "code": 6613,
+      "name": "NotProgramTransferAuthority"
     },
     {
       "code": 6614,
@@ -1803,7 +2123,10 @@
           {
             "name": "address",
             "type": {
-              "array": ["u8", 32]
+              "array": [
+                "u8",
+                32
+              ]
             }
           },
           {
@@ -1824,7 +2147,9 @@
         "fields": [
           {
             "name": "owner",
-            "docs": ["Program's owner."],
+            "docs": [
+              "Program's owner."
+            ],
             "type": "pubkey"
           },
           {
@@ -1835,17 +2160,23 @@
           },
           {
             "name": "owner_assistant",
-            "docs": ["Program's assistant. Can be used to update the relayer fee and swap rate."],
+            "docs": [
+              "Program's assistant. Can be used to update the relayer fee and swap rate."
+            ],
             "type": "pubkey"
           },
           {
             "name": "fee_updater",
-            "docs": ["Program's fee updater. Can be used to update fee parameters and the like."],
+            "docs": [
+              "Program's fee updater. Can be used to update fee parameters and the like."
+            ],
             "type": "pubkey"
           },
           {
             "name": "fee_recipient_token",
-            "docs": ["Program's fee recipient. Receives relayer fees in USDC."],
+            "docs": [
+              "Program's fee recipient. Receives relayer fees in USDC."
+            ],
             "type": "pubkey"
           }
         ]
@@ -1894,7 +2225,9 @@
     },
     {
       "name": "Peer",
-      "docs": ["Foreign Peer account data."],
+      "docs": [
+        "Foreign Peer account data."
+      ],
       "type": {
         "kind": "struct",
         "fields": [
@@ -1908,14 +2241,21 @@
           },
           {
             "name": "address",
-            "docs": ["Peer address. Cannot be zero address."],
+            "docs": [
+              "Peer address. Cannot be zero address."
+            ],
             "type": {
-              "array": ["u8", 32]
+              "array": [
+                "u8",
+                32
+              ]
             }
           },
           {
             "name": "relay_params",
-            "docs": ["Relay parameters."],
+            "docs": [
+              "Relay parameters."
+            ],
             "type": {
               "defined": {
                 "name": "RelayParams"
@@ -1932,7 +2272,9 @@
         "fields": [
           {
             "name": "chain",
-            "docs": ["Peer chain. Cannot equal `1` (Solana's Chain ID)."],
+            "docs": [
+              "Peer chain. Cannot equal `1` (Solana's Chain ID)."
+            ],
             "type": "u16"
           },
           {
@@ -1977,17 +2319,23 @@
         "fields": [
           {
             "name": "prepared_custody_token_bump",
-            "docs": ["Bump seed for the custody token account associated with [PreparedFill]."],
+            "docs": [
+              "Bump seed for the custody token account associated with [PreparedFill]."
+            ],
             "type": "u8"
           },
           {
             "name": "prepared_by",
-            "docs": ["Who paid the lamports to create the [PreparedFill] account."],
+            "docs": [
+              "Who paid the lamports to create the [PreparedFill] account."
+            ],
             "type": "pubkey"
           },
           {
             "name": "fill_type",
-            "docs": ["NOTE: If [FillType::Unset], the [PreparedFill] account is invalid."],
+            "docs": [
+              "NOTE: If [FillType::Unset], the [PreparedFill] account is invalid."
+            ],
             "type": {
               "defined": {
                 "name": "FillType"
@@ -1996,19 +2344,28 @@
           },
           {
             "name": "source_chain",
-            "docs": ["Wormhole chain ID reflecting where the order was created."],
+            "docs": [
+              "Wormhole chain ID reflecting where the order was created."
+            ],
             "type": "u16"
           },
           {
             "name": "order_sender",
-            "docs": ["Universal address of the order sender."],
+            "docs": [
+              "Universal address of the order sender."
+            ],
             "type": {
-              "array": ["u8", 32]
+              "array": [
+                "u8",
+                32
+              ]
             }
           },
           {
             "name": "redeemer",
-            "docs": ["Authority allowed to redeem [PreparedFill]."],
+            "docs": [
+              "Authority allowed to redeem [PreparedFill]."
+            ],
             "type": "pubkey"
           },
           {
@@ -2052,19 +2409,25 @@
             "fields": [
               {
                 "name": "gas_dropoff",
-                "docs": ["Normalized amount of gas to drop off on destination network."],
+                "docs": [
+                  "Normalized amount of gas to drop off on destination network."
+                ],
                 "type": "u32"
               },
               {
                 "name": "max_relayer_fee",
-                "docs": ["Maximum fee that a relayer can charge for the transfer."],
+                "docs": [
+                  "Maximum fee that a relayer can charge for the transfer."
+                ],
                 "type": "u64"
               }
             ]
           },
           {
             "name": "Payload",
-            "fields": ["bytes"]
+            "fields": [
+              "bytes"
+            ]
           }
         ]
       }
@@ -2111,7 +2474,9 @@
     },
     {
       "name": "StageOutboundArgs",
-      "docs": ["Arguments for [stage_outbound]."],
+      "docs": [
+        "Arguments for [stage_outbound]."
+      ],
       "type": {
         "kind": "struct",
         "fields": [
@@ -2138,14 +2503,21 @@
           },
           {
             "name": "target_chain",
-            "docs": ["The Wormhole chain ID of the network to transfer tokens to."],
+            "docs": [
+              "The Wormhole chain ID of the network to transfer tokens to."
+            ],
             "type": "u16"
           },
           {
             "name": "recipient",
-            "docs": ["The recipient of the transfer."],
+            "docs": [
+              "The recipient of the transfer."
+            ],
             "type": {
-              "array": ["u8", 32]
+              "array": [
+                "u8",
+                32
+              ]
             }
           },
           {
@@ -2206,29 +2578,42 @@
           },
           {
             "name": "staged_by",
-            "docs": ["Payer that created this StagedInbound."],
+            "docs": [
+              "Payer that created this StagedInbound."
+            ],
             "type": "pubkey"
           },
           {
             "name": "source_chain",
-            "docs": ["Exposed out of convenience for the receiving program."],
+            "docs": [
+              "Exposed out of convenience for the receiving program."
+            ],
             "type": "u16"
           },
           {
             "name": "sender",
-            "docs": ["The sender of the swap message."],
+            "docs": [
+              "The sender of the swap message."
+            ],
             "type": {
-              "array": ["u8", 32]
+              "array": [
+                "u8",
+                32
+              ]
             }
           },
           {
             "name": "recipient",
-            "docs": ["The encoded recipient must be the caller."],
+            "docs": [
+              "The encoded recipient must be the caller."
+            ],
             "type": "pubkey"
           },
           {
             "name": "is_native",
-            "docs": ["Indicates whether the output token type is Gas."],
+            "docs": [
+              "Indicates whether the output token type is Gas."
+            ],
             "type": "bool"
           }
         ]
@@ -2289,29 +2674,46 @@
           },
           {
             "name": "prepared_by",
-            "docs": ["One who paid the lamports to create [StagedOutbound]."],
+            "docs": [
+              "One who paid the lamports to create [StagedOutbound]."
+            ],
             "type": "pubkey"
           },
           {
             "name": "sender",
-            "docs": ["Sender of the swap message."],
+            "docs": [
+              "Sender of the swap message."
+            ],
             "type": "pubkey"
           },
           {
             "name": "target_chain",
-            "docs": ["Wormhole chain ID of the target network."],
+            "docs": [
+              "Wormhole chain ID of the target network."
+            ],
             "type": "u16"
           },
           {
             "name": "recipient",
-            "docs": ["Intended recipient of the transfer."],
+            "docs": [
+              "Intended recipient of the transfer.",
+              "",
+              "NOTE: This recipient will be set to the zero address after a swap is completed if there is",
+              "any dust remaining in the custody token account. Setting this to the zero address will",
+              "prevent replaying the same outbound swap."
+            ],
             "type": {
-              "array": ["u8", 32]
+              "array": [
+                "u8",
+                32
+              ]
             }
           },
           {
             "name": "is_exact_in",
-            "docs": ["This value is only checked for swaps."],
+            "docs": [
+              "This value is only checked for swaps."
+            ],
             "type": "bool"
           },
           {
@@ -2354,7 +2756,9 @@
           },
           {
             "name": "Payload",
-            "fields": ["bytes"]
+            "fields": [
+              "bytes"
+            ]
           }
         ]
       }

--- a/watcher/src/utils/solana.ts
+++ b/watcher/src/utils/solana.ts
@@ -37,7 +37,7 @@ export const findFromSignatureAndToSignature = async (
   connection: Connection,
   fromSlot: number,
   toSlot: number,
-  retries = 5
+  retries = 10 // 5 is too low, watcher gets stuck and throws error 
 ) => {
   let toBlock: VersionedBlockResponse;
   let fromBlock: VersionedBlockResponse;

--- a/watcher/src/watchers/FTSolanaWatcher.ts
+++ b/watcher/src/watchers/FTSolanaWatcher.ts
@@ -265,6 +265,8 @@ export class FTSolanaWatcher extends SolanaWatcher {
         );
       }
 
+      this.logger.info(`Processing transaction with signature: ${res.transaction.signatures[0]}`);
+
       const message = res.transaction.message;
       const instructions = message.compiledInstructions;
 


### PR DESCRIPTION
This PR attempts to fix everything once the mainnet contracts are fixed:

- `redeem_time` is nuillable since `complete_x_payload` is not considered as a real redeem until `release_inbound` is called (which is linked via `staged_inbound`)
- save `TransactionComplete` batch from Solana Swap Layer parser into db