### PR TITLE
watcher: make near archive watcher work

### DIFF
--- a/watcher/scripts/backfillArbitrum.ts
+++ b/watcher/scripts/backfillArbitrum.ts
@@ -30,7 +30,7 @@ import { Chain, contracts } from '@wormhole-foundation/sdk-base';
   const watcher = new ArbitrumWatcher('Mainnet');
   for (const blockNumber of blockNumbers) {
     log.text = `Fetching block ${blockNumber}`;
-    const vaasByBlock = await watcher.getMessagesForBlocks(blockNumber, blockNumber);
+    const { vaasByBlock } = await watcher.getMessagesForBlocks(blockNumber, blockNumber);
     await db.storeVaasByBlock(chain, vaasByBlock);
   }
   log.succeed('Uploaded messages to db successfully');

--- a/watcher/scripts/locateMessageGaps.ts
+++ b/watcher/scripts/locateMessageGaps.ts
@@ -115,7 +115,9 @@ import { ChainId, Network, toChain, toChainId } from '@wormhole-foundation/sdk-b
       while (fromBlock <= rangeEnd && !found) {
         const toBlock = Math.min(fromBlock + watcher.maximumBatchSize - 1, rangeEnd);
         const messages = await watcher.getMessagesForBlocks(fromBlock, toBlock);
-        for (const message of Object.entries(messages).filter(([key, value]) => value.length > 0)) {
+        for (const message of Object.entries(messages.vaasByBlock).filter(
+          ([key, value]) => value.length > 0
+        )) {
           const locatedMessages = message[1].filter((msgKey) => {
             const [_transaction, vaaKey] = msgKey.split(':');
             const [_chain, msgEmitter, msgSeq] = vaaKey.split('/');

--- a/watcher/src/consts.ts
+++ b/watcher/src/consts.ts
@@ -3,7 +3,7 @@ import { Mode } from '@wormhole-foundation/wormhole-monitor-common';
 import { AxiosRequestConfig } from 'axios';
 
 export const TIMEOUT = 0.5 * 1000;
-export const HB_INTERVAL = 5 * 60 * 1000; // 5 Minutes
+export const HB_INTERVAL = 15 * 60 * 1000; // 15 Minutes
 export type WorkerData = {
   network: Network;
   chain: Chain;

--- a/watcher/src/watchers/AlgorandWatcher.ts
+++ b/watcher/src/watchers/AlgorandWatcher.ts
@@ -98,7 +98,10 @@ export class AlgorandWatcher extends Watcher {
     return messages;
   }
 
-  async getMessagesForBlocks(fromBlock: number, toBlock: number): Promise<VaasByBlock> {
+  async getMessagesForBlocks(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<{ vaasByBlock: VaasByBlock; optionalBlockHeight?: number }> {
     const txIds = await this.getApplicationLogTransactionIds(fromBlock, toBlock);
     const transactions = [];
     for (const txId of txIds) {
@@ -124,6 +127,6 @@ export class AlgorandWatcher extends Watcher {
     if (!vaasByBlock[toBlockKey]) {
       vaasByBlock[toBlockKey] = [];
     }
-    return vaasByBlock;
+    return { vaasByBlock };
   }
 }

--- a/watcher/src/watchers/AptosWatcher.ts
+++ b/watcher/src/watchers/AptosWatcher.ts
@@ -40,7 +40,10 @@ export class AptosWatcher extends Watcher {
     );
   }
 
-  async getMessagesForBlocks(fromSequence: number, toSequence: number): Promise<VaasByBlock> {
+  async getMessagesForBlocks(
+    fromSequence: number,
+    toSequence: number
+  ): Promise<{ vaasByBlock: VaasByBlock; optionalBlockHeight?: number }> {
     const limit = toSequence - fromSequence + 1;
     const events: AptosEvent[] = (await this.client.getEventsByEventHandle(
       this.coreBridgeAddress,
@@ -63,7 +66,7 @@ export class AptosWatcher extends Watcher {
         vaasByBlock[blockKey] = [...(vaasByBlock[blockKey] ?? []), vaaKey];
       })
     );
-    return vaasByBlock;
+    return { vaasByBlock };
   }
 
   isValidBlockKey(key: string) {

--- a/watcher/src/watchers/CosmwasmWatcher.ts
+++ b/watcher/src/watchers/CosmwasmWatcher.ts
@@ -55,7 +55,10 @@ export class CosmwasmWatcher extends Watcher {
     throw new Error(`Unable to parse result of ${this.latestBlockTag} on ${this.rpc}`);
   }
 
-  async getMessagesForBlocks(fromBlock: number, toBlock: number): Promise<VaasByBlock> {
+  async getMessagesForBlocks(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<{ vaasByBlock: VaasByBlock; optionalBlockHeight?: number }> {
     const address = contracts.coreBridge.get(this.network, this.chain);
     if (!address) {
       throw new Error(`Core contract not defined for ${this.chain}`);
@@ -153,7 +156,7 @@ export class CosmwasmWatcher extends Watcher {
         }
       }
     }
-    return vaasByBlock;
+    return { vaasByBlock };
   }
 }
 

--- a/watcher/src/watchers/EVMWatcher.ts
+++ b/watcher/src/watchers/EVMWatcher.ts
@@ -40,6 +40,7 @@ export class EVMWatcher extends Watcher {
     this.lastTimestamp = 0;
     this.latestFinalizedBlockNumber = 0;
     this.finalizedBlockTag = finalizedBlockTag;
+    // Special cases for batch size
     if (chain === 'Acala' || chain === 'Karura' || chain === 'Berachain') {
       this.maximumBatchSize = 50;
     } else if (
@@ -54,6 +55,10 @@ export class EVMWatcher extends Watcher {
       chain === 'Xlayer'
     ) {
       this.maximumBatchSize = 10;
+    }
+    // Special cases for watch loop delay
+    if (chain === 'Berachain') {
+      this.watchLoopDelay = 1000;
     }
   }
 
@@ -221,7 +226,10 @@ export class EVMWatcher extends Watcher {
     return block.number;
   }
 
-  async getMessagesForBlocks(fromBlock: number, toBlock: number): Promise<VaasByBlock> {
+  async getMessagesForBlocks(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<{ vaasByBlock: VaasByBlock; optionalBlockHeight?: number }> {
     const address = contracts.coreBridge.get(this.network, this.chain);
     if (!address) {
       throw new Error(`Core contract not defined for ${this.chain} on ${this.network}!`);
@@ -252,6 +260,6 @@ export class EVMWatcher extends Watcher {
       const blockKey = makeBlockKey(blockNumber.toString(), timestampsByBlock[blockNumber]);
       vaasByBlock[blockKey] = [...(vaasByBlock[blockKey] || []), vaaKey];
     }
-    return vaasByBlock;
+    return { vaasByBlock };
   }
 }

--- a/watcher/src/watchers/InjectiveExplorerWatcher.ts
+++ b/watcher/src/watchers/InjectiveExplorerWatcher.ts
@@ -47,7 +47,10 @@ export class InjectiveExplorerWatcher extends Watcher {
   // should be core, but the explorer doesn't support it yet
   // use "to": as the pagination key
   // compare block height ("block_number":) with what is passed in.
-  async getMessagesForBlocks(fromBlock: number, toBlock: number): Promise<VaasByBlock> {
+  async getMessagesForBlocks(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<{ vaasByBlock: VaasByBlock; optionalBlockHeight?: number }> {
     const coreAddress = contracts.coreBridge.get(this.network, this.chain);
     const address = contracts.tokenBridge.get(this.network, this.chain);
     if (!coreAddress || !address) {
@@ -169,7 +172,7 @@ export class InjectiveExplorerWatcher extends Watcher {
       );
       vaasByBlock[blockKey] = [];
     }
-    return vaasByBlock;
+    return { vaasByBlock };
   }
 }
 

--- a/watcher/src/watchers/NearWatcher.ts
+++ b/watcher/src/watchers/NearWatcher.ts
@@ -22,7 +22,10 @@ export class NearWatcher extends Watcher {
     return block.header.height;
   }
 
-  async getMessagesForBlocks(fromBlock: number, toBlock: number): Promise<VaasByBlock> {
+  async getMessagesForBlocks(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<{ vaasByBlock: VaasByBlock; optionalBlockHeight?: number }> {
     // assume toBlock was retrieved from getFinalizedBlockNumber and is finalized
     this.logger.info(`fetching info for blocks ${fromBlock} to ${toBlock}`);
     const provider = await this.getProvider();
@@ -48,7 +51,9 @@ export class NearWatcher extends Watcher {
       }
     }
 
-    return getMessagesFromBlockResults(this.network, provider, blocks);
+    return {
+      vaasByBlock: await getMessagesFromBlockResults(this.network, provider, blocks),
+    };
   }
 
   async getProvider(): Promise<Provider> {

--- a/watcher/src/watchers/SeiExplorerWatcher.ts
+++ b/watcher/src/watchers/SeiExplorerWatcher.ts
@@ -107,7 +107,10 @@ export class SeiExplorerWatcher extends CosmwasmWatcher {
 
   // retrieve blocks for core contract
   // compare block height with what is passed in
-  async getMessagesForBlocks(fromBlock: number, toBlock: number): Promise<VaasByBlock> {
+  async getMessagesForBlocks(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<{ vaasByBlock: VaasByBlock; optionalBlockHeight?: number }> {
     const address = contracts.coreBridge.get(this.network, this.chain);
     if (!address) {
       throw new Error(`Core contract not defined for ${this.chain}`);
@@ -237,6 +240,6 @@ export class SeiExplorerWatcher extends CosmwasmWatcher {
     }
     // NOTE: this does not set an empty entry for the latest block since we don't know if the graphql response
     // is synced with the block height. Therefore, the latest block will only update when a new transaction appears.
-    return vaasByBlock;
+    return { vaasByBlock };
   }
 }

--- a/watcher/src/watchers/SolanaWatcher.ts
+++ b/watcher/src/watchers/SolanaWatcher.ts
@@ -81,7 +81,10 @@ export class SolanaWatcher extends Watcher {
     return block;
   }
 
-  async getMessagesForBlocks(fromSlot: number, toSlot: number): Promise<VaasByBlock> {
+  async getMessagesForBlocks(
+    fromSlot: number,
+    toSlot: number
+  ): Promise<{ vaasByBlock: VaasByBlock; optionalBlockHeight?: number }> {
     // in the rare case of maximumBatchSize skipped blocks in a row,
     // you might hit this error due to the recursion below
     if (fromSlot > toSlot) throw new Error('solana: invalid block range');
@@ -251,7 +254,7 @@ export class SolanaWatcher extends Watcher {
       toSlot.toString(),
       new Date(toBlock.blockTime! * 1000).toISOString()
     );
-    return { [lastBlockKey]: [], ...vaasByBlock };
+    return { vaasByBlock: { [lastBlockKey]: [], ...vaasByBlock } };
   }
 
   isValidVaaKey(key: string) {

--- a/watcher/src/watchers/SuiWatcher.ts
+++ b/watcher/src/watchers/SuiWatcher.ts
@@ -39,7 +39,10 @@ export class SuiWatcher extends Watcher {
   }
 
   // TODO: this might break using numbers, the whole service needs a refactor to use BigInt
-  async getMessagesForBlocks(fromCheckpoint: number, toCheckpoint: number): Promise<VaasByBlock> {
+  async getMessagesForBlocks(
+    fromCheckpoint: number,
+    toCheckpoint: number
+  ): Promise<{ vaasByBlock: VaasByBlock; optionalBlockHeight?: number }> {
     this.logger.info(`fetching info for checkpoints ${fromCheckpoint} to ${toCheckpoint}`);
     const vaasByBlock: VaasByBlock = {};
 
@@ -115,6 +118,6 @@ export class SuiWatcher extends Watcher {
         vaasByBlock[blockKey] = [...(vaasByBlock[blockKey] || []), vaaKey];
       }
     } while (hasNextPage && lastCheckpoint && fromCheckpoint < lastCheckpoint);
-    return vaasByBlock;
+    return { vaasByBlock };
   }
 }

--- a/watcher/src/watchers/TerraExplorerWatcher.ts
+++ b/watcher/src/watchers/TerraExplorerWatcher.ts
@@ -43,7 +43,10 @@ export class TerraExplorerWatcher extends Watcher {
   // retrieve blocks for core contract.
   // use "next": as the pagination key
   // compare block height ("height":) with what is passed in.
-  async getMessagesForBlocks(fromBlock: number, toBlock: number): Promise<VaasByBlock> {
+  async getMessagesForBlocks(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<{ vaasByBlock: VaasByBlock; optionalBlockHeight?: number }> {
     const address = contracts.coreBridge.get(this.network, this.chain);
     if (!address) {
       throw new Error(`Core contract not defined for ${this.chain}`);
@@ -159,7 +162,7 @@ export class TerraExplorerWatcher extends Watcher {
       );
       vaasByBlock[blockKey] = [];
     }
-    return vaasByBlock;
+    return { vaasByBlock };
   }
 }
 

--- a/watcher/src/watchers/WormchainWatcher.ts
+++ b/watcher/src/watchers/WormchainWatcher.ts
@@ -37,7 +37,10 @@ export class WormchainWatcher extends CosmwasmWatcher {
     throw new Error(`Unable to parse result of ${this.latestBlockTag} on ${this.rpc}`);
   }
 
-  async getMessagesForBlocks(fromBlock: number, toBlock: number): Promise<VaasByBlock> {
+  async getMessagesForBlocks(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<{ vaasByBlock: VaasByBlock; optionalBlockHeight?: number }> {
     const address = contracts.coreBridge.get(this.network, this.chain);
     if (!address) {
       throw new Error(`Core contract not defined for ${this.chain}`);
@@ -135,7 +138,7 @@ export class WormchainWatcher extends CosmwasmWatcher {
         }
       }
     }
-    return vaasByBlock;
+    return { vaasByBlock };
   }
 }
 

--- a/watcher/src/watchers/__tests__/AlgorandWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/AlgorandWatcher.test.ts
@@ -16,13 +16,16 @@ test('getFinalizedBlockNumber', async () => {
 
 test('getMessagesForBlocks', async () => {
   const watcher = new AlgorandWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(25692450, 25692450);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(25692450, 25692450);
   expect(messages).toMatchObject({ '25692450/2022-12-21T02:00:40.000Z': [] });
 });
 
 test('getMessagesForBlocks initial block', async () => {
   const watcher = new AlgorandWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(initialAlgorandBlock, initialAlgorandBlock);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(
+    initialAlgorandBlock,
+    initialAlgorandBlock
+  );
   expect(messages).toMatchObject({
     '22931277/2022-08-19T15:10:48.000Z': [
       '2RBQLCETCLFV4F3PQ7IHEWVWQV3MCP4UM5S5OFZM23XMC2O2DJ6A:8/67e93fa6c8ac5c819990aa7340c0c16b508abb1178be9b30d024b8ac25193d45/1',
@@ -32,13 +35,16 @@ test('getMessagesForBlocks initial block', async () => {
 
 test('getMessagesForBlocks indexer pagination support', async () => {
   const watcher = new AlgorandWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(initialAlgorandBlock, 27069946);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(
+    initialAlgorandBlock,
+    27069946
+  );
   expect(Object.keys(messages).length).toEqual(420);
 });
 
 test('getMessagesForBlocks seq < 192', async () => {
   const watcher = new AlgorandWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(25428873, 25428873);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(25428873, 25428873);
   expect(messages).toMatchObject({
     '25428873/2022-12-09T18:10:08.000Z': [
       'M6QPEZ42P5O23II7SCWZTNZ7MHBSOH6KUNAPMH5YL3XHGNTEFUSQ:8/67e93fa6c8ac5c819990aa7340c0c16b508abb1178be9b30d024b8ac25193d45/191',
@@ -48,7 +54,7 @@ test('getMessagesForBlocks seq < 192', async () => {
 
 test('getMessagesForBlocks seq = 192', async () => {
   const watcher = new AlgorandWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(25433218, 25433218);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(25433218, 25433218);
   expect(messages).toMatchObject({
     '25433218/2022-12-09T22:40:55.000Z': [
       '3PJPDBGTQK6JXAQEJNOYFE4NLLKFMCTKRY5FYNAXSEBDO25XUUJQ:8/67e93fa6c8ac5c819990aa7340c0c16b508abb1178be9b30d024b8ac25193d45/192',
@@ -58,7 +64,7 @@ test('getMessagesForBlocks seq = 192', async () => {
 
 test('getMessagesForBlocks seq > 383', async () => {
   const watcher = new AlgorandWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(26856742, 26856742);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(26856742, 26856742);
   expect(messages).toMatchObject({
     '26856742/2023-02-09T09:05:04.000Z': [
       'LJNYXPG5VLJNNTBLSZSHLZQ7XQWTSUPKGA7APVI53J3MAKHQN72Q:8/67e93fa6c8ac5c819990aa7340c0c16b508abb1178be9b30d024b8ac25193d45/384',
@@ -68,6 +74,6 @@ test('getMessagesForBlocks seq > 383', async () => {
 
 test('getMessagesForBlocks on known empty block', async () => {
   const watcher = new AlgorandWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(23761195, 23761195);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(23761195, 23761195);
   expect(messages).toMatchObject({ '23761195/2022-09-28T21:42:30.000Z': [] });
 });

--- a/watcher/src/watchers/__tests__/AptosWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/AptosWatcher.test.ts
@@ -16,7 +16,7 @@ test('getFinalizedSequenceNumber', async () => {
 
 test('getMessagesForSequenceNumbers', async () => {
   const watcher = new AptosWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(0, 1);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(0, 1);
   expect(messages).toMatchObject({
     '1095891/2022-10-19T00:55:54.676Z/0': [
       '0x27b5808a7cfdb688e02be192ed334da683975b7487e8be7a09670b3088b58908:22/0000000000000000000000000000000000000000000000000000000000000001/0',
@@ -32,12 +32,11 @@ test('getMessagesForSequenceNumbers', async () => {
 
   // test that block number, timestamp, and sequence number are all strictly increasing
   const latestSequenceNumber = await watcher.getFinalizedBlockNumber();
-  const messageKeys = Object.keys(
-    await watcher.getMessagesForBlocks(
-      latestSequenceNumber - watcher.maximumBatchSize + 1,
-      latestSequenceNumber
-    )
-  ).sort();
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(
+    latestSequenceNumber - watcher.maximumBatchSize + 1,
+    latestSequenceNumber
+  );
+  const messageKeys = Object.keys(vaasByBlock).sort();
   console.log(messageKeys);
   expect(messageKeys.length).toBe(watcher.maximumBatchSize);
   expect(Date.parse(messageKeys.at(-1)!.split('/')[1])).toBeLessThan(Date.now());

--- a/watcher/src/watchers/__tests__/ArbitrumWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/ArbitrumWatcher.test.ts
@@ -24,7 +24,7 @@ test('getFinalizedBlockNumber', async () => {
 
 test('getMessagesForBlocks', async () => {
   const watcher = new ArbitrumWatcher('Mainnet');
-  const vaasByBlock = await watcher.getMessagesForBlocks(114500582, 114500584);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(114500582, 114500584);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(3);
   expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(2);

--- a/watcher/src/watchers/__tests__/BaseWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/BaseWatcher.test.ts
@@ -14,7 +14,7 @@ test('getFinalizedBlockNumber', async () => {
 
 test('getMessagesForBlocks', async () => {
   const watcher = new EVMWatcher('Mainnet', 'Base');
-  const vaasByBlock = await watcher.getMessagesForBlocks(1544175, 1544185);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(1544175, 1544185);
   expect(vaasByBlock).toMatchObject({
     '1544175/2023-07-20T18:28:17.000Z': [],
     '1544176/2023-07-20T18:28:19.000Z': [],
@@ -32,7 +32,7 @@ test('getMessagesForBlocks', async () => {
 
 test('getMessagesForBlockWithWHMsg', async () => {
   const watcher = new EVMWatcher('Mainnet', 'Base');
-  const vaasByBlock = await watcher.getMessagesForBlocks(1557420, 1557429);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(1557420, 1557429);
   expect(vaasByBlock).toMatchObject({
     '1557420/2023-07-21T01:49:47.000Z': [],
     '1557421/2023-07-21T01:49:49.000Z': [],

--- a/watcher/src/watchers/__tests__/CosmwasmWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/CosmwasmWatcher.test.ts
@@ -17,7 +17,7 @@ test.skip('getFinalizedBlockNumber(terra2)', async () => {
 
 test.skip('getMessagesForBlocks(terra2)', async () => {
   const watcher = new TerraExplorerWatcher('Mainnet', 'Terra2');
-  const vaasByBlock = await watcher.getMessagesForBlocks(10847656, 10847657);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(10847656, 10847657);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(2);
   expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(1);
@@ -38,7 +38,7 @@ test('getFinalizedBlockNumber(terra explorer)', async () => {
 
 test('getMessagesForBlocks(terra explorer)', async () => {
   const watcher = new TerraExplorerWatcher('Mainnet', 'Terra');
-  const vaasByBlock = await watcher.getMessagesForBlocks(14506733, 14506740);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(14506733, 14506740);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(2);
   expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(1);
@@ -54,7 +54,7 @@ test('getMessagesForBlocks(terra explorer)', async () => {
 // flaky rpc, skip
 test.skip('getMessagesForBlocks(terra explorer, no useful info)', async () => {
   const watcher = new TerraExplorerWatcher('Mainnet', 'Terra');
-  const vaasByBlock = await watcher.getMessagesForBlocks(10975000, 10975010);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(10975000, 10975010);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(1);
   expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(1);
@@ -70,7 +70,7 @@ test('getFinalizedBlockNumber(xpla)', async () => {
 
 test('getMessagesForBlocks(xpla)', async () => {
   const watcher = new CosmwasmWatcher('Mainnet', 'Xpla');
-  const vaasByBlock = await watcher.getMessagesForBlocks(1645812, 1645813);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(1645812, 1645813);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(2);
   expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(1);
@@ -91,7 +91,7 @@ test('getFinalizedBlockNumber(injective)', async () => {
 
 test.skip('getMessagesForBlocks(injective)', async () => {
   const watcher = new InjectiveExplorerWatcher('Mainnet');
-  const vaasByBlock = await watcher.getMessagesForBlocks(61720293, 61720294);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(61720293, 61720294);
   const entries = Object.entries(vaasByBlock);
   // console.log(entries); // Leave this in for future debugging
   expect(entries.length).toEqual(2);
@@ -115,7 +115,7 @@ test.skip('getFinalizedBlockNumber(sei)', async () => {
 // skipped because the SeiExplorerWatcher is used
 test.skip('getMessagesForBlocks(sei)', async () => {
   const watcher = new CosmwasmWatcher('Mainnet', 'Sei');
-  const vaasByBlock = await watcher.getMessagesForBlocks(18907686, 18907687);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(18907686, 18907687);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(2);
   expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(1);
@@ -138,7 +138,7 @@ test('getFinalizedBlockNumber(sei explorer)', async () => {
 // skipped because it takes more and more time to paginate back
 test.skip('getMessagesForBlocks(sei explorer)', async () => {
   const watcher = new SeiExplorerWatcher('Mainnet');
-  const vaasByBlock = await watcher.getMessagesForBlocks(19061244, 19061245);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(19061244, 19061245);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(1);
   expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(0);
@@ -161,7 +161,7 @@ test('getFinalizedBlockNumber(wormchain)', async () => {
 
 test('getMessagesForBlocks(wormchain)', async () => {
   const watcher = new WormchainWatcher('Mainnet');
-  const vaasByBlock = await watcher.getMessagesForBlocks(8978585, 8978585);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(8978585, 8978585);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(1);
   expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(0);

--- a/watcher/src/watchers/__tests__/EVMWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/EVMWatcher.test.ts
@@ -72,7 +72,7 @@ test('getFinalizedBlockNumber', async () => {
 
 test('getMessagesForBlocks', async () => {
   const watcher = new EVMWatcher('Mainnet', 'Avalanche');
-  const vaasByBlock = await watcher.getMessagesForBlocks(46997500, 46997599);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(46997500, 46997599);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(100);
   expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(99);
@@ -111,7 +111,7 @@ test('getBlock by number (Celo compatibility)', async () => {
 
 test('getMessagesForBlocks (Celo compatibility)', async () => {
   const watcher = new EVMWatcher('Mainnet', 'Celo');
-  const vaasByBlock = await watcher.getMessagesForBlocks(13322450, 13322549);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(13322450, 13322549);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(100);
   expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(98);
@@ -142,7 +142,7 @@ test('getBlock by number (Karura compatibility)', async () => {
 
 test('getMessagesForBlocks (Karura compatibility)', async () => {
   const watcher = new EVMWatcher('Mainnet', 'Karura');
-  const vaasByBlock = await watcher.getMessagesForBlocks(4582511, 4582513);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(4582511, 4582513);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(3);
   expect(entries[0][0]).toEqual('4582511/2023-06-19T15:54:48.000Z');
@@ -155,7 +155,7 @@ test('getMessagesForBlocks (Karura compatibility)', async () => {
 test('getMessagesForBlocks (Karura compatibility 2)', async () => {
   const watcher = new EVMWatcher('Mainnet', 'Karura');
   await watcher.getFinalizedBlockNumber(); // This has the side effect of initializing the latestFinalizedBlockNumber
-  const vaasByBlock = await watcher.getMessagesForBlocks(4595356, 4595358);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(4595356, 4595358);
   const entries = Object.entries(vaasByBlock);
   expect(entries.length).toEqual(3);
 });

--- a/watcher/src/watchers/__tests__/OptimismWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/OptimismWatcher.test.ts
@@ -17,7 +17,7 @@ test('getFinalizedBlockNumber', async () => {
 
 test('getMessagesForBlocks', async () => {
   const watcher = new EVMWatcher('Mainnet', 'Optimism');
-  const vaasByBlock = await watcher.getMessagesForBlocks(105235070, 105235080);
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(105235070, 105235080);
   expect(vaasByBlock).toMatchObject({
     '105235070/2023-06-06T16:28:37.000Z': [],
     '105235071/2023-06-06T16:28:39.000Z': [],

--- a/watcher/src/watchers/__tests__/SolanaWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/SolanaWatcher.test.ts
@@ -16,7 +16,7 @@ test('getFinalizedBlockNumber', async () => {
 
 test('getMessagesForBlocks - single block', async () => {
   const watcher = new SolanaWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(170799004, 170799004);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(170799004, 170799004);
   expect(Object.keys(messages).length).toBe(1);
   expect(messages).toMatchObject({
     '170799004/2023-01-04T16:43:43.000Z': [
@@ -32,21 +32,21 @@ test('getMessagesForBlocks - single block', async () => {
 // temporary skip due to SolanaJSONRPCError: failed to get confirmed block: Block 171774030 cleaned up, does not exist on node. First available block: 176896202
 test('getMessagesForBlocks - fromSlot is skipped slot', async () => {
   const watcher = new SolanaWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(171774030, 171774032); // 171774024 - 171774031 are skipped
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(171774030, 171774032); // 171774024 - 171774031 are skipped
   expect(Object.keys(messages).length).toBe(1);
   expect(messages).toMatchObject({ '171774032/2023-01-10T13:36:39.000Z': [] });
 });
 
 test('getMessagesForBlocks - toSlot is skipped slot', async () => {
   const watcher = new SolanaWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(171774023, 171774025);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(171774023, 171774025);
   expect(messages).toMatchObject({ '171774025/2023-01-10T13:36:34.000Z': [] });
 });
 
 test('getMessagesForBlocks - empty block', async () => {
   // Even if there are no messages, last block should still be returned
   const watcher = new SolanaWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(170979766, 170979766);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(170979766, 170979766);
   expect(Object.keys(messages).length).toBe(1);
   expect(messages).toMatchObject({ '170979766/2023-01-05T18:40:25.000Z': [] });
 });
@@ -58,25 +58,25 @@ test('getMessagesForBlocks - block with no transactions', async () => {
     'solana: invalid block range'
   );
 
-  let messages = await watcher.getMessagesForBlocks(174108661, 174108861);
+  let { vaasByBlock: messages } = await watcher.getMessagesForBlocks(174108661, 174108861);
   expect(Object.keys(messages).length).toBe(1);
   expect(Object.values(messages).flat().length).toBe(0);
 
-  messages = await watcher.getMessagesForBlocks(174108863, 174109061);
+  ({ vaasByBlock: messages } = await watcher.getMessagesForBlocks(174108863, 174109061));
   expect(Object.keys(messages).length).toBe(1);
   expect(Object.values(messages).flat().length).toBe(0);
 });
 
 test('getMessagesForBlocks - multiple blocks', async () => {
   const watcher = new SolanaWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(171050470, 171050474);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(171050470, 171050474);
   expect(Object.keys(messages).length).toBe(2);
   expect(Object.values(messages).flat().length).toBe(2);
 });
 
 test('getMessagesForBlocks - multiple blocks, last block empty', async () => {
   const watcher = new SolanaWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(170823000, 170825000);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(170823000, 170825000);
   expect(Object.keys(messages).length).toBe(3);
   expect(Object.values(messages).flat().length).toBe(2); // 2 messages, last block has no message
 });
@@ -84,16 +84,16 @@ test('getMessagesForBlocks - multiple blocks, last block empty', async () => {
 test('getMessagesForBlocks - multiple blocks containing more than `getSignaturesLimit` WH transactions', async () => {
   const watcher = new SolanaWatcher('Mainnet');
   watcher.getSignaturesLimit = 10;
-  const messages = await watcher.getMessagesForBlocks(171582367, 171583452);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(171582367, 171583452);
   expect(Object.keys(messages).length).toBe(3);
   expect(Object.values(messages).flat().length).toBe(3);
 });
 
 test('getMessagesForBlocks - multiple calls', async () => {
   const watcher = new SolanaWatcher('Mainnet');
-  const messages1 = await watcher.getMessagesForBlocks(171773021, 171773211);
-  const messages2 = await watcher.getMessagesForBlocks(171773212, 171773250);
-  const messages3 = await watcher.getMessagesForBlocks(171773251, 171773500);
+  const { vaasByBlock: messages1 } = await watcher.getMessagesForBlocks(171773021, 171773211);
+  const { vaasByBlock: messages2 } = await watcher.getMessagesForBlocks(171773212, 171773250);
+  const { vaasByBlock: messages3 } = await watcher.getMessagesForBlocks(171773251, 171773500);
   const allMessageKeys = [
     ...Object.keys(messages1),
     ...Object.keys(messages2),
@@ -105,7 +105,7 @@ test('getMessagesForBlocks - multiple calls', async () => {
 
 test('getMessagesForBlocks - handle failed transactions', async () => {
   const watcher = new SolanaWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(94401321, 94501321);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(94401321, 94501321);
   expect(Object.keys(messages).length).toBe(6);
   expect(Object.values(messages).flat().length).toBe(5);
   expect(

--- a/watcher/src/watchers/__tests__/SuiWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/SuiWatcher.test.ts
@@ -19,7 +19,7 @@ test('getFinalizedSequenceNumber', async () => {
 // works backwards.  This will cause a 429 until we clear that up.
 test.skip('getMessagesForBlocks', async () => {
   const watcher = new SuiWatcher('Mainnet');
-  const messages = await watcher.getMessagesForBlocks(1581997, 1581997);
+  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(1581997, 1581997);
   console.log(messages);
   const entries = Object.entries(messages);
   expect(entries.length).toEqual(46);


### PR DESCRIPTION
This PR addresses the Near explorer endpoint having a low amount of requests per day.  The code is more efficient to conserve these requests.