### PR TITLE
watcher: change Terra2 watcher

### DIFF
--- a/watcher/src/watchers/CosmwasmWatcher.ts
+++ b/watcher/src/watchers/CosmwasmWatcher.ts
@@ -30,6 +30,8 @@ export class CosmwasmWatcher extends Watcher {
     this.latestBlockHeight = 0;
     if (chain === 'Sei') {
       this.maximumBatchSize = 1;
+    } else if (chain === 'Terra2') {
+      this.maximumBatchSize = 10;
     }
   }
 

--- a/watcher/src/watchers/utils.ts
+++ b/watcher/src/watchers/utils.ts
@@ -63,8 +63,10 @@ export function makeFinalizedWatcher(network: Network, chainName: Chain): Watche
     return new InjectiveExplorerWatcher(network);
   } else if (chainName === 'Sei') {
     return new SeiExplorerWatcher(network);
-  } else if (chainName === 'Terra' || chainName === 'Terra2') {
+  } else if (chainName === 'Terra') {
     return new TerraExplorerWatcher(network, chainName);
+  } else if (chainName === 'Terra2') {
+    return new CosmwasmWatcher(network, chainName);
   } else if (chainName === 'Xpla') {
     return new CosmwasmWatcher(network, chainName);
   } else if (chainName === 'Sui') {


### PR DESCRIPTION
For some reason the Terra2 explorers aren't being updated to contain current information.  So, need to move the Terra2 watcher back to the Cosmwasm watcher.