### PR TITLE
Add Unichain mainnet support

### DIFF
--- a/common/src/consts.ts
+++ b/common/src/consts.ts
@@ -50,6 +50,7 @@ export const INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN: NetworkChainBlockMap
     Sei: '238594',
     Wormchain: '4510119', // https://bigdipper.live/wormhole/transactions/4D861F1BE86325D227FA006CA2745BBC6748AF5B5E0811DE536D02792928472A  },
     Snaxchain: '306315',
+    Unichain: '8115676', // https://unichain.blockscout.com/tx/0x4d65e33abc388c2d92c71ea01374af935a6615d0e555a7abbdef6c44e04613ba
     Worldchain: '5805110', // https://worldscan.org/tx/0x568eb14596296bda3022527cf0e915bfec073613b27c495e695fb9e08652f6fc
   },
   ['Testnet']: {
@@ -88,7 +89,6 @@ export const INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN: NetworkChainBlockMap
     Unichain: '254961', // Block of contract creation
     Worldchain: '4487948', // Block of contract creation
     Monad: '520060', // Block of contract creation
-    MonadDevnet: '3670467', // Block of contract creation
     Ink: '1907965', // Block of contract creation
     HyperEVM: '13743181', // Block of contract creation
   },

--- a/common/src/explorer.ts
+++ b/common/src/explorer.ts
@@ -72,6 +72,8 @@ export const explorerBlock = (network: Network, chainId: ChainId, block: string)
       ? `https://beratrail.io/block/${block}`
       : chainId === chainToChainId('Snaxchain')
       ? `https://snaxchain.io/${block}`
+      : chainId === chainToChainId('Unichain')
+      ? `https://unichain.blockscout.com/block/${block}`
       : chainId === chainToChainId('Wormchain')
       ? `https://bigdipper.live/wormhole/blocks/${block}`
       : chainId === chainToChainId('Worldchain')
@@ -142,8 +144,6 @@ export const explorerBlock = (network: Network, chainId: ChainId, block: string)
     ? `https://worldchain-sepolia.explorer.alchemy.com/block/${block}`
     : chainId === chainToChainId('Monad')
     ? `${process.env.MONAD_EXPLORER_URL}/block/${block}`
-    : chainId === chainToChainId('MonadDevnet')
-    ? `${process.env.MONAD_DEVNET_EXPLORER_URL}/block/${block}`
     : chainId === chainToChainId('Ink')
     ? `https://explorer-sepolia.inkonchain.com/block/${block}`
     : chainId === chainToChainId('HyperEVM')
@@ -215,6 +215,8 @@ export const explorerTx = (network: Network, chainId: ChainId, tx: string) =>
       ? `https://bartio.beratrail.io/tx/${tx}`
       : chainId === chainToChainId('Snaxchain')
       ? `https://snaxchain.io/tx/${tx}`
+      : chainId === chainToChainId('Unichain')
+      ? `https://unichain.blockscout.com/tx/${tx}`
       : chainId === chainToChainId('Wormchain')
       ? `https://bigdipper.live/wormhole/transactions/${tx}`
       : chainId === chainToChainId('Worldchain')
@@ -285,8 +287,6 @@ export const explorerTx = (network: Network, chainId: ChainId, tx: string) =>
     ? `https://worldchain-sepolia.explorer.alchemy.com/tx/${tx}`
     : chainId === chainToChainId('Monad')
     ? `${process.env.MONAD_EXPLORER_URL}/tx/${tx}`
-    : chainId === chainToChainId('MonadDevnet')
-    ? `${process.env.MONAD_DEVNET_EXPLORER_URL}/tx/${tx}`
     : chainId === chainToChainId('Ink')
     ? `https://explorer-sepolia.inkonchain.com/tx/${tx}`
     : chainId === chainToChainId('HyperEVM')

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,7 +17,7 @@
     "@types/node": "^18.6.4",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
-    "@wormhole-foundation/sdk-icons": "^1.4.4",
+    "@wormhole-foundation/sdk-icons": "^1.6.0",
     "buffer": "^6.0.3",
     "numeral": "^2.0.6",
     "react": "^18.2.0",

--- a/database/package.json
+++ b/database/package.json
@@ -15,7 +15,7 @@
     "@injectivelabs/sdk-ts": "^1.0.368",
     "@mysten/sui.js": "^0.50.1",
     "@terra-money/terra.js": "^3.1.3",
-    "@wormhole-foundation/sdk": "^1.4.4",
+    "@wormhole-foundation/sdk": "^1.6.0",
     "@xpla/xpla.js": "^0.2.3",
     "aptos": "1.5.0",
     "dotenv": "^16.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,13 @@
       ],
       "dependencies": {
         "@google-cloud/functions-framework": "^3.4.0",
-        "@wormhole-foundation/sdk-base": "^1.4.4",
-        "@wormhole-foundation/sdk-definitions": "^1.4.4",
-        "@wormhole-foundation/sdk-evm": "^1.4.4",
-        "@wormhole-foundation/sdk-evm-core": "^1.4.4",
-        "@wormhole-foundation/sdk-icons": "^1.4.4",
-        "@wormhole-foundation/sdk-solana": "^1.4.4",
-        "@wormhole-foundation/sdk-solana-core": "^1.4.4",
+        "@wormhole-foundation/sdk-base": "^1.6.0",
+        "@wormhole-foundation/sdk-definitions": "^1.6.0",
+        "@wormhole-foundation/sdk-evm": "^1.6.0",
+        "@wormhole-foundation/sdk-evm-core": "^1.6.0",
+        "@wormhole-foundation/sdk-icons": "^1.6.0",
+        "@wormhole-foundation/sdk-solana": "^1.6.0",
+        "@wormhole-foundation/sdk-solana-core": "^1.6.0",
         "axios": "^1.5.0"
       },
       "devDependencies": {
@@ -167,7 +167,7 @@
         "@types/node": "^18.6.4",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
-        "@wormhole-foundation/sdk-icons": "^1.4.4",
+        "@wormhole-foundation/sdk-icons": "^1.6.0",
         "buffer": "^6.0.3",
         "numeral": "^2.0.6",
         "react": "^18.2.0",
@@ -201,7 +201,7 @@
         "@injectivelabs/sdk-ts": "^1.0.368",
         "@mysten/sui.js": "^0.50.1",
         "@terra-money/terra.js": "^3.1.3",
-        "@wormhole-foundation/sdk": "^1.4.4",
+        "@wormhole-foundation/sdk": "^1.6.0",
         "@xpla/xpla.js": "^0.2.3",
         "aptos": "1.5.0",
         "dotenv": "^16.0.3",
@@ -305,6 +305,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-cli/-/aptos-cli-1.0.2.tgz",
       "integrity": "sha512-PYPsd0Kk3ynkxNfe3S4fanI3DiUICCoh4ibQderbvjPFL5A0oK6F4lPEO2t0MDsQySTk2t4vh99Xjy6Bd9y+aQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.1.0"
       },
@@ -316,6 +317,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-0.1.1.tgz",
       "integrity": "sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.7.4",
         "got": "^11.8.6"
@@ -328,6 +330,7 @@
       "version": "1.33.1",
       "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.33.1.tgz",
       "integrity": "sha512-d6nWtUI//fyEN8DeLjm3+ro87Ad6+IKwR9pCqfrs/Azahso1xR1Llxd/O6fj/m1DDsuDj/HAsCsy5TC/aKD6Eg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/aptos-cli": "^1.0.2",
         "@aptos-labs/aptos-client": "^0.1.1",
@@ -348,7 +351,8 @@
     "node_modules/@aptos-labs/ts-sdk/node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.6",
@@ -7011,6 +7015,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -7573,6 +7578,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -8036,6 +8042,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -8113,7 +8120,8 @@
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
@@ -8358,6 +8366,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -8511,6 +8520,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -9586,47 +9596,50 @@
       "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.4.4.tgz",
-      "integrity": "sha512-QWcvpFwhyfthcIemz29Zy2nWlJxcZ4zu3+GrK2D4JiiLTM5kIdFOXA++MI+W23IY4fftF0aDSx+s72MdBxVrBw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.6.0.tgz",
+      "integrity": "sha512-4IFqPHDS4T623CYpohvB+V0QEG2Xu434L9Pxz9lRkCK+FTyOJNZg7Vg+z3Jq0ekG758v7O9lm4pCmIGZaXMe9w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.4.4",
-        "@wormhole-foundation/sdk-algorand-core": "1.4.4",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.4.4",
-        "@wormhole-foundation/sdk-aptos": "1.4.4",
-        "@wormhole-foundation/sdk-aptos-core": "1.4.4",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.4.4",
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-cosmwasm": "1.4.4",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.4.4",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.4.4",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
-        "@wormhole-foundation/sdk-evm": "1.4.4",
-        "@wormhole-foundation/sdk-evm-cctp": "1.4.4",
-        "@wormhole-foundation/sdk-evm-core": "1.4.4",
-        "@wormhole-foundation/sdk-evm-portico": "1.4.4",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.4.4",
-        "@wormhole-foundation/sdk-solana": "1.4.4",
-        "@wormhole-foundation/sdk-solana-cctp": "1.4.4",
-        "@wormhole-foundation/sdk-solana-core": "1.4.4",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "1.4.4",
-        "@wormhole-foundation/sdk-sui": "1.4.4",
-        "@wormhole-foundation/sdk-sui-cctp": "1.4.4",
-        "@wormhole-foundation/sdk-sui-core": "1.4.4",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "1.4.4"
+        "@wormhole-foundation/sdk-algorand": "1.6.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.6.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.6.0",
+        "@wormhole-foundation/sdk-aptos": "1.6.0",
+        "@wormhole-foundation/sdk-aptos-cctp": "1.6.0",
+        "@wormhole-foundation/sdk-aptos-core": "1.6.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.6.0",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.6.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.6.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.6.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
+        "@wormhole-foundation/sdk-evm": "1.6.0",
+        "@wormhole-foundation/sdk-evm-cctp": "1.6.0",
+        "@wormhole-foundation/sdk-evm-core": "1.6.0",
+        "@wormhole-foundation/sdk-evm-portico": "1.6.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.6.0",
+        "@wormhole-foundation/sdk-solana": "1.6.0",
+        "@wormhole-foundation/sdk-solana-cctp": "1.6.0",
+        "@wormhole-foundation/sdk-solana-core": "1.6.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "1.6.0",
+        "@wormhole-foundation/sdk-sui": "1.6.0",
+        "@wormhole-foundation/sdk-sui-cctp": "1.6.0",
+        "@wormhole-foundation/sdk-sui-core": "1.6.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.4.4.tgz",
-      "integrity": "sha512-XkUDoJtXZ5LZgAOIhKs6ZP+OB41zfpAcX0yNs9wEvbEjbtIQimKSHSUURYzD1+dBBPQtDt2PhOWCswxeurx0Dw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.6.0.tgz",
+      "integrity": "sha512-65uL6KaQnB3p2jT//kNH9ah8CBmQrM+0f4zlJsKvOMA6I/JwC7I8Ch4i/pOfaGSgOEAVfFP/1h65N7C/pq06CA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.4.4",
+        "@wormhole-foundation/sdk-connect": "1.6.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -9634,24 +9647,26 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.4.4.tgz",
-      "integrity": "sha512-jzncA1nnu7VbEmp01LyWCxLCde4xvyDcy5owNeM+b+IaWmHXt/rwmqIXtD5a20J39IAdmEHYEW2TY3Ua/79LwQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.6.0.tgz",
+      "integrity": "sha512-C1M0LujxFNRhP27Mdd02GtmJKm9gl7AfesiHrVBATMiUOxWA2GxAAFtzeTLtVrjJfLiuxRe6NWwWTwpKZGp3dA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.4.4",
-        "@wormhole-foundation/sdk-connect": "1.4.4"
+        "@wormhole-foundation/sdk-algorand": "1.6.0",
+        "@wormhole-foundation/sdk-connect": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -9659,25 +9674,27 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.4.4.tgz",
-      "integrity": "sha512-WD2WSl5wsx+w+o/Da2anFQOHD6m4k39B8VkZQe1bRHbWu5rz1VTHYgpjHh1jVysc0FeZT+sKdIdGdjOhPuobPA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.6.0.tgz",
+      "integrity": "sha512-XFBHdQE2t2VQWgefbE98DLT9HoPL2YXdk7Vyd/kpVPvuLUqCOTpQJBfovSfO+P3i84jq7VYh544nrce5qSuSOw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.4.4",
-        "@wormhole-foundation/sdk-algorand-core": "1.4.4",
-        "@wormhole-foundation/sdk-connect": "1.4.4"
+        "@wormhole-foundation/sdk-algorand": "1.6.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.6.0",
+        "@wormhole-foundation/sdk-connect": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -9685,12 +9702,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -9698,36 +9716,67 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.4.4.tgz",
-      "integrity": "sha512-oENv3wi7I2AE18yWkTCcj710Wax4HlGNukSXz/Dq9xosbwaC5L2mlfzLvYFksXYiUbKOAlDTVllNIOR+8qSNZw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.6.0.tgz",
+      "integrity": "sha512-KKmXAOSR/KjFmvxXv/v0UFnhijieK1uOSR9w4k0ke57g4RcrP5cASqGss6ROUot2iOwdk0BV3ZvxaXlUATib1w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^1.33.1",
-        "@wormhole-foundation/sdk-connect": "1.4.4"
+        "@wormhole-foundation/sdk-connect": "1.6.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-1.6.0.tgz",
+      "integrity": "sha512-TXAnis/FUWzkgXpeT43C/RbEXHuFJpwqoGT40PrvcvcYsr+qaG/5YdOWAuKEjKeVa2+57A1eZFMym2O/mNSgYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aptos-labs/ts-sdk": "^1.33.1",
+        "@wormhole-foundation/sdk-aptos": "1.6.0",
+        "@wormhole-foundation/sdk-connect": "1.6.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-aptos-cctp/node_modules/@wormhole-foundation/sdk-connect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
+        "axios": "^1.4.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.4.4.tgz",
-      "integrity": "sha512-2QF5g8wiUsSxEPWiTcN8UGcdFtaUduydahsocCcXJj76ZlDVJg37hLYsJj5o1rqNqhmt4OOvz0DDOMWo2JmogA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.6.0.tgz",
+      "integrity": "sha512-48+GCePfHdLl936XPmoM8yf8hGAvB7lFRaVAwtw1J7szXN8dNZNhxpyJtIoxy/ezI19exqzsLd/mLORsNvH/Rg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.4.4",
-        "@wormhole-foundation/sdk-connect": "1.4.4"
+        "@wormhole-foundation/sdk-aptos": "1.6.0",
+        "@wormhole-foundation/sdk-connect": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -9735,24 +9784,26 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.4.4.tgz",
-      "integrity": "sha512-v32rc91LoNuXa38UCGdivofyp0jYlwwPuG3EDu4gVQDuXtq2A447RMF9MLiEOqSwvQDH6/JS656nnVCd5J9htA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.6.0.tgz",
+      "integrity": "sha512-+14bqQG+1IGIL+1QcQx+t4MxSYvLMM9dGA8BlIMaseKxpfF7awwlX/m+1a4I0iloLv3XqqGgvCaMycl3kc3R6g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.4.4",
-        "@wormhole-foundation/sdk-connect": "1.4.4"
+        "@wormhole-foundation/sdk-aptos": "1.6.0",
+        "@wormhole-foundation/sdk-connect": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -9760,12 +9811,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -9773,9 +9825,10 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.4.4.tgz",
-      "integrity": "sha512-i6Hm46FjBj3bamivSw5UWEAvIRsy63Oww7AaZpmt2CXyeGJgj+UM20f5+Wd+jBaRKmQRzkEiWqFNKuf6HZmFPg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.6.0.tgz",
+      "integrity": "sha512-ahjdVIT9pRN/uuRwH26P+1V8gQpvVd07MYjID1clHt84t4T+FSeqVq36YWT1Ad2UZyYKN+bR9PNPGx4rm6Iqew==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
         "binary-layout": "^1.0.3"
@@ -9813,15 +9866,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.4.4.tgz",
-      "integrity": "sha512-nHoOaoi7qWKqLs0P9MwdgbZK0KPobczNIW1xT4USEeyWVpuY9f45z5GdEDF3wn+pCOqLBCN6dfm00D4E0dNI3w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.6.0.tgz",
+      "integrity": "sha512-TpoZbXrdLa3SXBQTW8q5/MeD7zIcdk0nFGx+HxOSexLzN2M0xmWhxzzEKoHvMkAajpUup+jNW/ekONr3SMOkFw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
+        "@wormhole-foundation/sdk-connect": "1.6.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -9829,15 +9883,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.4.4.tgz",
-      "integrity": "sha512-FCkxUt4oE1BpJ3QebX4gKx4bjU+3S1I8fOu+hGEIaWPX32m/lOieT5T0ovzzy1grnxlljVyXgnhbcfC2Z93ZPQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.6.0.tgz",
+      "integrity": "sha512-6hTz5rojnBFaX+WO+Q4PMcRU0FQRkYGh7fCJ3M08mrF7TxqKVJs7rbIpJjMSQusLdSEGB0nA2MTgn6rPmFJHBg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-cosmwasm": "1.4.4"
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.6.0"
       },
       "engines": {
         "node": ">=16"
@@ -9847,6 +9902,7 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
       "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -9861,12 +9917,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -9874,16 +9931,17 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.4.4.tgz",
-      "integrity": "sha512-FhjXk2h+W9nAfn+qV55i+DKHCvz9t7JMnu2HOVmGKU/7SAhF5oVIYxr26VDyk3KWJ/JgbyB4zSgYoC8IEz/Pgw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.6.0.tgz",
+      "integrity": "sha512-xukjkj+JyJflvIQR4PqtqCmIbrgyvTzx6yA6aO9IK3yvNv5reYZELv5tzk3O94q2BdLkrnq3gJiqITSYE8P0OA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-cosmwasm": "1.4.4",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.4.4",
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.6.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.6.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -9894,6 +9952,7 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
       "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -9908,12 +9967,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -9921,14 +9981,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.4.4.tgz",
-      "integrity": "sha512-Mj9M0dfEwCGAoGs2KigX34vZKyZgGvT/mfcbYrxXDvkX0tyXmzvo1mzU3J09LDLm8io8r4/wB2OcDvxWb74IXw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.6.0.tgz",
+      "integrity": "sha512-F071qpbUpya7hlEp7eg2d4pejN9p73iGWS9+yFsasJpzNaS9frBK++2v+Vfjr374Tqf+A8O+toeZeJEx4dgcMg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-cosmwasm": "1.4.4"
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.6.0"
       },
       "engines": {
         "node": ">=16"
@@ -9938,6 +9999,7 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
       "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -9952,12 +10014,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -9968,6 +10031,7 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
       "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -9982,12 +10046,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -9995,13 +10060,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.4.4.tgz",
-      "integrity": "sha512-bD8J3Y0dAGgx0k2IgpKlZoRqRw0/WiAebZnMwVsgGfg3W1ZIk0XkB2BP3lMmmLu6zMMjBjPCqTn6O+xPnz/MbA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.6.0.tgz",
+      "integrity": "sha512-WAsc+EsnNs6J38CBoQNvB6l1/7T/GwGQheqGc2AeretxRY7LOuDqm7sXesVpr8mGHkLn7paN0neyidUndX7KwQ==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "1.4.4"
+        "@wormhole-foundation/sdk-base": "1.6.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions-ntt": {
@@ -10033,11 +10098,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.4.4.tgz",
-      "integrity": "sha512-6Lhp/jqahi2ejEyCnuXSlAGS38ay1puvxqdz2ApltCKKo4lL+S3iXE+Pl8YHiDz+F6eXZeIbxki0SiPEraLB3g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.6.0.tgz",
+      "integrity": "sha512-b20EMLNWlJyIZNYkq0RrlWf5+MwRF9BgMz4nJTwhFkWYGPnmDOZZR37pu7rj3XReP49VPL5fTaj9boE8voc9bg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.4.4",
+        "@wormhole-foundation/sdk-connect": "1.6.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -10045,12 +10111,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.4.4.tgz",
-      "integrity": "sha512-agcjYI0lSuBhINDDhMKdYe+7UccAJtT9Tl4HV1q10Hfc7Cq10eyB/Qe16oBx8UEj6bigxWOe8veNlW7venVmvg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.6.0.tgz",
+      "integrity": "sha512-vag2zgHafggdtdS+k6vFaQqsDG39W4sa9WuTZQTk84PmceCshybvyfQSRL8ESReTCZZEO0/IrYzdfgqlsaGk7Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-evm": "1.4.4",
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-evm": "1.6.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -10061,6 +10128,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -10072,6 +10140,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -10083,17 +10152,19 @@
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -10103,7 +10174,8 @@
     "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/ethers": {
       "version": "6.13.5",
@@ -10119,6 +10191,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -10135,12 +10208,14 @@
     "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10158,12 +10233,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.4.4.tgz",
-      "integrity": "sha512-hI5KwBCb4oQd0vu8Rf4ry9iTgjGFDsaHtxZX3BfGidfNjYvVFhCJMADRPSQ8tVKp0EOucQ5/m+zuVIXGw1s3qg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.6.0.tgz",
+      "integrity": "sha512-2yWoVOia38x8RFY6TboP2S6iZ6eCr3cFdO6S4iFLb2PdgXF+N90S0NVDpnqYv3RoF8BfdxbeTkjMI3z0/wteBA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-evm": "1.4.4",
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-evm": "1.6.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -10174,6 +10250,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -10185,6 +10262,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -10196,17 +10274,19 @@
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -10216,7 +10296,8 @@
     "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/ethers": {
       "version": "6.13.5",
@@ -10232,6 +10313,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -10248,12 +10330,14 @@
     "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10426,14 +10510,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.4.4.tgz",
-      "integrity": "sha512-THjVAMX4pLP0RWbD2ep0tPG1AAC95Vlsi4l/EtRBRPPqXda/VSNG+/G0W+bmCfxO1eyuNg7hUO8yNp1QJDugpw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.6.0.tgz",
+      "integrity": "sha512-KFNfLm60mXmjjAY2hIuM70evc18dlx9v8XC6Awr4or68nU3RsKwUi31sKBH7wRl22qHGZqUgmGt+QJVzc/o7Ag==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-evm": "1.4.4",
-        "@wormhole-foundation/sdk-evm-core": "1.4.4",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.4.4",
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-evm": "1.6.0",
+        "@wormhole-foundation/sdk-evm-core": "1.6.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.6.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -10444,6 +10529,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -10455,6 +10541,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -10466,17 +10553,19 @@
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -10486,7 +10575,8 @@
     "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/ethers": {
       "version": "6.13.5",
@@ -10502,6 +10592,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -10518,12 +10609,14 @@
     "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10541,13 +10634,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.4.4.tgz",
-      "integrity": "sha512-EQ/uaP5tmDI9qfamz4f3HYQoEM2lXfPvbl63c4hLu32Fe3rli/9lYoD4FzvdzrhEzlR5nrHoCt1Vohmws87N3w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.6.0.tgz",
+      "integrity": "sha512-tG32B0j36Loq1Yz1u9HgaIIEmm6tdS3KNyyLJ3Lyv1xU5MyYylQIFgyMBcoZYWHffOKDkGRO7x+0dZRndneFog==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-evm": "1.4.4",
-        "@wormhole-foundation/sdk-evm-core": "1.4.4",
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-evm": "1.6.0",
+        "@wormhole-foundation/sdk-evm-core": "1.6.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -10558,6 +10652,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -10569,6 +10664,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -10580,17 +10676,19 @@
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -10600,7 +10698,8 @@
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/ethers": {
       "version": "6.13.5",
@@ -10616,6 +10715,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -10632,12 +10732,14 @@
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10682,12 +10784,13 @@
       "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
     },
     "node_modules/@wormhole-foundation/sdk-evm/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -10752,23 +10855,25 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-icons": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-icons/-/sdk-icons-1.4.4.tgz",
-      "integrity": "sha512-RaEk98YlXEk7wtlBLcB8hVnKubjfW8cKdSJzMj3UcrQhiyPmOKRuOTsD4IyO8uJRjwLCxdf8a/1STzr3V5zYsg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-icons/-/sdk-icons-1.6.0.tgz",
+      "integrity": "sha512-oubCSbkj/kNtsqRQmrhazJ+oac4E7fpIPUSQDowtPRv8+nh220PI4ieOWYVIyPkc4djbOb7ydvatO2v4D6WgDw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4"
+        "@wormhole-foundation/sdk-base": "1.6.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.4.4.tgz",
-      "integrity": "sha512-6Sr8Py+qewXnfVdafgCxN6MFtA8QwhKh5PQi9Zvi4GlJMM1qHxSEy5uLwHyORTVGghpZmOFweYhkDQl073GzDA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.6.0.tgz",
+      "integrity": "sha512-ALuNx35JvjUrYHqQSbygJtXOwn8jYkooxj1GAYRWrHkPh3Ih6Fd1dY2JmmaBc6lt+gjlOCSkb9iQI0tBLQn67w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
+        "@wormhole-foundation/sdk-connect": "1.6.0",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -10776,27 +10881,29 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.4.4.tgz",
-      "integrity": "sha512-6v4hXydSmDiooQVA9MMatL332WjDoHZVrtIGnNqax7Fxd0gHQE1hIBMD/Re3UeT/SCViPEUMQ8+VBY7amhwEMw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.6.0.tgz",
+      "integrity": "sha512-YXK0lXkCzL1+yiiExE83NOowqncp2dNZvTrIO1NTC1lhmqBgEecF5OACDLW6y6rNc0oyngO95QpT/eVLiPs0rw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-solana": "1.4.4"
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-solana": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -10804,27 +10911,29 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.4.4.tgz",
-      "integrity": "sha512-ACo+Gak4P7xLcSZyH9koAO55CAkpBX62osZMgU6KtB8JnEP0jiUtWj6SNo1eiT5+3KNmcCZQr4VDd0ka+E6kSw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.6.0.tgz",
+      "integrity": "sha512-eOgGC8h1u83+jMXc4x+DZEPQau+9PtKMZ84RGD8axwUAdYrKCpNSp2/1oW1GS5OqqcVJ9swX0wjB5SzOaCS/9A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-solana": "1.4.4"
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-solana": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -10971,28 +11080,30 @@
       "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.4.4.tgz",
-      "integrity": "sha512-zB+BSDHycxEpOoPXfRkrqZPEsubwc7huzBEufNeVfFBcoJjdD+WHm5TULkeA0Uj2DiZYD9Jf+Kp1OY3q9M8xDw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.6.0.tgz",
+      "integrity": "sha512-R7lmfuKcT/g9q7LE2myNj/2yTpAYL0jCx8ca5dGsLqBGFFXGWUnkDT90H1nCAxFNoary66D8I2C2NfU344iTnw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-solana": "1.4.4",
-        "@wormhole-foundation/sdk-solana-core": "1.4.4"
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-solana": "1.6.0",
+        "@wormhole-foundation/sdk-solana-core": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -11000,12 +11111,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -11013,37 +11125,40 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.4.4.tgz",
-      "integrity": "sha512-jND/nUwMvS1j4rprJkujEAGjl38CTLBpLmAl+s0UmNRVIZ/M0rnjBKzPh68OFRJZsLsJ9QgJ2EjZdmEePg82HQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.6.0.tgz",
+      "integrity": "sha512-PsOR9ORAdVrtxmnTfInFKrJwUr6bJWVlnZC5jgRc7XWO4UapXpClUnyidV1xBqyMtkvqqO6qnq9oxOfqhh7NvQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.4.4"
+        "@wormhole-foundation/sdk-connect": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-1.4.4.tgz",
-      "integrity": "sha512-dFt+kSIt2NBXkowthdrfoFHTjjQCCWmTOT+Jtv4a2gVF5Z/mdp8DiL0/Q1e9x0hDEE008Jh5pan9V1HO98ldzQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-1.6.0.tgz",
+      "integrity": "sha512-W9zPopHS30OFJdUW34J/E9OOjbSk2W+kjUj+HrVqz97nCi9aSOHJ1RK3GKeMGHJYJ8R5+g3wMqhNvKlleeXbgw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-sui": "1.4.4"
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-sui": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -11051,25 +11166,27 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.4.4.tgz",
-      "integrity": "sha512-StVL0CJiCvyYV8TZAymPcqsXwNPCMUqIBzpeGAwAa86QMfl6N6fKdjA65sgYrxC5hPLyS4KhJn7lEsKTrUC7Uw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.6.0.tgz",
+      "integrity": "sha512-PZxhKB03RP0p5HPcT9g79f5d94mQeWwAHGOlumDnLIu8chAJWHmO9Lpuw/m0ANgoc1YqgSbiisfG9QyUPkfH7w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-sui": "1.4.4"
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-sui": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -11077,26 +11194,28 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.4.4.tgz",
-      "integrity": "sha512-hHooaVlGzQqvMPhf/8Zt/08SFup+kT+gtgQgKWvCyUAm+1TNu2UZaUfrOHoh5A4wiNmbFO5iaTTeJmBD2IKDVQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.6.0.tgz",
+      "integrity": "sha512-bRe9Z5XBhwEG/RlQvGHv/eLIaH2BKpQVfX99ffWkR+RUvXTLjWyRunOKN4mEpJd0OMWZ4tBJVA7tOA+2MxvPow==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.4.4",
-        "@wormhole-foundation/sdk-sui": "1.4.4",
-        "@wormhole-foundation/sdk-sui-core": "1.4.4"
+        "@wormhole-foundation/sdk-connect": "1.6.0",
+        "@wormhole-foundation/sdk-sui": "1.6.0",
+        "@wormhole-foundation/sdk-sui-core": "1.6.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -11104,12 +11223,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -11117,12 +11237,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.4.4.tgz",
-      "integrity": "sha512-YDBDgsglmp9IeyxieTQ3SWDwOaPqR5+FtKhuQ4gXef8AgzJgrhg5yVtFRS1L6E+SV+zMbtwKvY2qywVSfLjYnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.6.0.tgz",
+      "integrity": "sha512-3tiBZFKKvQ+DicvyYPnOW/x7mos8nCaJYMZScSd/0YDIrZ8ltz2QKPKrwbFRF5d5YYXrk7cEJeyIvVYACkMNyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.4.4",
-        "@wormhole-foundation/sdk-definitions": "1.4.4",
+        "@wormhole-foundation/sdk-base": "1.6.0",
+        "@wormhole-foundation/sdk-definitions": "1.6.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -12494,6 +12615,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
       }
@@ -12502,6 +12624,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -12519,6 +12642,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -12696,6 +12820,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -13225,6 +13350,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -13239,6 +13365,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -13330,6 +13457,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -15728,6 +15856,7 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -15985,7 +16114,8 @@
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
       "version": "1.8.1",
@@ -16037,6 +16167,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -18279,7 +18410,8 @@
     "node_modules/js-base64": {
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
-      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-sha256": {
       "version": "0.9.0",
@@ -18548,6 +18680,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
       "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -18991,6 +19124,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -19240,6 +19374,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -19467,6 +19602,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -19807,6 +19943,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -20125,7 +20262,8 @@
     "node_modules/poseidon-lite": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.2.1.tgz",
-      "integrity": "sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog=="
+      "integrity": "sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
@@ -20538,6 +20676,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -20963,7 +21102,8 @@
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -21011,6 +21151,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.4.0",
-    "@wormhole-foundation/sdk-base": "^1.4.4",
-    "@wormhole-foundation/sdk-definitions": "^1.4.4",
-    "@wormhole-foundation/sdk-evm": "^1.4.4",
-    "@wormhole-foundation/sdk-evm-core": "^1.4.4",
-    "@wormhole-foundation/sdk-icons": "^1.4.4",
-    "@wormhole-foundation/sdk-solana": "^1.4.4",
-    "@wormhole-foundation/sdk-solana-core": "^1.4.4",
+    "@wormhole-foundation/sdk-base": "^1.6.0",
+    "@wormhole-foundation/sdk-definitions": "^1.6.0",
+    "@wormhole-foundation/sdk-evm": "^1.6.0",
+    "@wormhole-foundation/sdk-evm-core": "^1.6.0",
+    "@wormhole-foundation/sdk-icons": "^1.6.0",
+    "@wormhole-foundation/sdk-solana": "^1.6.0",
+    "@wormhole-foundation/sdk-solana-core": "^1.6.0",
     "axios": "^1.5.0"
   }
 }

--- a/watcher/src/consts.ts
+++ b/watcher/src/consts.ts
@@ -63,6 +63,7 @@ export const RPCS_BY_CHAIN: { [key in Network]: { [key in Chain]?: string } } = 
     Wormchain: process.env.WORMCHAIN_RPC || 'https://wormchain-rpc.quickapi.com',
     Xlayer: process.env.XLAYER_RPC || 'https://rpc.ankr.com/xlayer',
     Snaxchain: process.env.SNAXCHAIN_RPC || 'https://snaxchain.io',
+    Unichain: process.env.UNICHAIN_RPC, // TODO: There is no Unichain public endpoint yet.
     Worldchain: process.env.WORLDCHAIN_RPC || 'https://worldchain-mainnet.g.alchemy.com/public',
   },
   ['Testnet']: {
@@ -107,7 +108,6 @@ export const RPCS_BY_CHAIN: { [key in Network]: { [key in Chain]?: string } } = 
     Unichain: process.env.UNICHAIN_RPC || 'https://sepolia.unichain.org',
     Worldchain: process.env.WORLDCHAIN_RPC || 'https://worldchain-sepolia.g.alchemy.com/public',
     Monad: process.env.MONAD_RPC, // TODO: There is no Monad public endpoint.
-    MonadDevnet: process.env.MONAD_DEVNET_RPC, // TODO: There is no Monad Devnet public endpoint.
     Ink: process.env.INK_RPC || 'https://rpc-qnd-sepolia.inkonchain.com',
     HyperEVM: process.env.HYPER_EVM_RPC || 'https://api.hyperliquid-testnet.xyz/evm',
   },

--- a/watcher/src/index.ts
+++ b/watcher/src/index.ts
@@ -58,7 +58,6 @@ const supportedChains: Chain[] =
         'Unichain',
         'Worldchain',
         'Monad',
-        'MonadDevnet',
         'Ink',
         'HyperEVM',
       ]
@@ -93,6 +92,7 @@ const supportedChains: Chain[] =
         'Blast',
         'Xlayer',
         'Snaxchain',
+        'Unichain',
         'Worldchain',
         'Wormchain',
       ];

--- a/watcher/src/watchers/EVMWatcher.ts
+++ b/watcher/src/watchers/EVMWatcher.ts
@@ -51,7 +51,6 @@ export class EVMWatcher extends Watcher {
       chain === 'Unichain' ||
       chain === 'Worldchain' ||
       chain === 'Monad' ||
-      chain === 'MonadDevnet' ||
       chain === 'Ink' ||
       chain === 'HyperEVM' ||
       chain === 'Seievm' ||

--- a/watcher/src/watchers/utils.ts
+++ b/watcher/src/watchers/utils.ts
@@ -46,7 +46,6 @@ export function makeFinalizedWatcher(network: Network, chainName: Chain): Watche
     chainName === 'Unichain' ||
     chainName === 'Worldchain' ||
     chainName === 'Monad' ||
-    chainName === 'MonadDevnet' ||
     chainName === 'Ink' ||
     chainName === 'HyperEVM' ||
     chainName === 'Base'


### PR DESCRIPTION
The core is available [here](https://unichain-d7a86fxp.blockscout.com/address/0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D).

This PR also removes support for MonadDevnet which is now obsolete.