### PR TITLE
dashboard: filter unknown chains

### DIFF
--- a/dashboard/src/components/Settings.tsx
+++ b/dashboard/src/components/Settings.tsx
@@ -26,6 +26,7 @@ function SettingsContent() {
     updateBackgroundUrl,
     updateTheme,
     updateShowChainName,
+    updateShowUnknownChains,
     updateShowAllMisses,
     updateShowMonitorDetails,
   } = useSettingsContext();
@@ -52,6 +53,12 @@ function SettingsContent() {
       updateShowChainName(event.target.checked);
     },
     [updateShowChainName]
+  );
+  const handleShowUnknownChainsChange = useCallback(
+    (event: any) => {
+      updateShowUnknownChains(event.target.checked);
+    },
+    [updateShowUnknownChains]
   );
   const handleShowAllMisses = useCallback(
     (event: any) => {
@@ -107,6 +114,17 @@ function SettingsContent() {
             <Checkbox checked={!!settings.showChainName} onChange={handleShowChainNameChange} />
           }
           label="Show chain names"
+        />
+      </Box>
+      <Box m={2}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={!!settings.showUnknownChains}
+              onChange={handleShowUnknownChainsChange}
+            />
+          }
+          label="Show unknown chains"
         />
       </Box>
       <Box m={2}>

--- a/dashboard/src/contexts/SettingsContext.tsx
+++ b/dashboard/src/contexts/SettingsContext.tsx
@@ -9,6 +9,7 @@ type Settings = {
   backgroundOpacity?: number;
   theme: Theme;
   showChainName?: boolean;
+  showUnknownChains?: boolean;
   showAllMisses?: boolean;
   showMonitorDetails?: boolean;
 };
@@ -19,6 +20,7 @@ type SettingsContextValue = {
   updateBackgroundUrl(value: string): void;
   updateTheme(value: Theme): void;
   updateShowChainName(value: boolean): void;
+  updateShowUnknownChains(value: boolean): void;
   updateShowAllMisses(value: boolean): void;
   updateShowMonitorDetails(value: boolean): void;
 };
@@ -56,6 +58,7 @@ const SettingsContext = React.createContext<SettingsContextValue>({
   updateBackgroundUrl: (value: string) => {},
   updateTheme: (value: Theme) => {},
   updateShowChainName: (value: boolean) => {},
+  updateShowUnknownChains: (value: boolean) => {},
   updateShowAllMisses: (value: boolean) => {},
   updateShowMonitorDetails: (value: boolean) => {},
 });
@@ -74,6 +77,9 @@ export const SettingsContextProvider = ({ children }: { children: ReactNode }) =
   const updateShowChainName = useCallback((value: boolean) => {
     setSettings((settings) => ({ ...settings, showChainName: value }));
   }, []);
+  const updateShowUnknownChains = useCallback((value: boolean) => {
+    setSettings((settings) => ({ ...settings, showUnknownChains: value }));
+  }, []);
   const updateShowAllMisses = useCallback((value: boolean) => {
     setSettings((settings) => ({ ...settings, showAllMisses: value }));
   }, []);
@@ -91,6 +97,7 @@ export const SettingsContextProvider = ({ children }: { children: ReactNode }) =
       updateBackgroundUrl,
       updateTheme,
       updateShowChainName,
+      updateShowUnknownChains,
       updateShowAllMisses,
       updateShowMonitorDetails,
     }),
@@ -100,6 +107,7 @@ export const SettingsContextProvider = ({ children }: { children: ReactNode }) =
       updateBackgroundUrl,
       updateTheme,
       updateShowChainName,
+      updateShowUnknownChains,
       updateShowAllMisses,
       updateShowMonitorDetails,
     ]

--- a/dashboard/src/utils/nativeAsset.ts
+++ b/dashboard/src/utils/nativeAsset.ts
@@ -23,7 +23,7 @@ const tryUint8ArrayToNative = (a: Uint8Array, chain: number): string => {
       return base58.encode(a);
     }
   } catch (e) {
-    console.error(`Failed to convert chain ${chain} to Chain:`, e);
+    // console.error(`Failed to convert chain ${chain} to Chain:`, e);
   }
   return `0x${Buffer.from(a).toString('hex')}`;
 };


### PR DESCRIPTION
This PR filters out unknown chain ids from the accountant and misses displays. It also adds a new setting to show the unknown chains.