### PR TITLE
fix(dashboard): placeholder heartbeats for missing guardians

### DIFF
--- a/common/src/consts.ts
+++ b/common/src/consts.ts
@@ -255,12 +255,7 @@ export const NTT_ACCOUNTANT_CONTRACT_ADDRESS_MAINNET =
 export const NTT_ACCOUNTANT_CONTRACT_ADDRESS_TESTNET =
   'wormhole169tvyx49zmjqhlv7mzwj8j2weprascc0jq3rdglw9pynldqx34nscvhc7k';
 
-export const STANDBY_GUARDIANS = [
-  {
-    pubkey: '0x68c16a92903c4c74ffddc730582ba53d967d3dac',
-    name: 'Google Cloud',
-  },
-];
+export const STANDBY_GUARDIANS: { pubkey: `0x${string}`; name: string }[] = [];
 
 export type GuardianSetInfo = {
   timestamp: string;

--- a/dashboard/src/components/Chains.tsx
+++ b/dashboard/src/components/Chains.tsx
@@ -275,10 +275,17 @@ function Chain({
               conditionalRowStyle={conditionalRowStyle}
             />
           )}
-          <Typography variant="subtitle1" sx={{ mt: 2, mb: 1 }}>
-            Standby Guardians
-          </Typography>
-          <ChainDetails heartbeats={standbyHeartbeats} conditionalRowStyle={conditionalRowStyle} />
+          {STANDBY_GUARDIANS.length === 0 ? null : (
+            <>
+              <Typography variant="subtitle1" sx={{ mt: 2, mb: 1 }}>
+                Standby Guardians
+              </Typography>
+              <ChainDetails
+                heartbeats={standbyHeartbeats}
+                conditionalRowStyle={conditionalRowStyle}
+              />
+            </>
+          )}
         </DialogContent>
       </Dialog>
     </>

--- a/dashboard/src/components/Guardians.tsx
+++ b/dashboard/src/components/Guardians.tsx
@@ -501,31 +501,39 @@ function Guardians({
               />
             ))}
           </Box>
-          <Typography variant="subtitle1" sx={{ mt: 2, mb: 1 }}>
-            Standby Guardians
-          </Typography>
-          <Box display="flex" flexWrap="wrap" alignItems="center" justifyContent={'center'}>
-            {standbyHeartbeats.map((hb) => (
-              <GuardianCard
-                key={`${hb.guardianAddr}-${hb.nodeName}`}
-                heartbeat={hb}
-                highestByChain={highestByChain}
-                latestRelease={latestRelease}
-              />
-            ))}
-          </Box>
+          {STANDBY_GUARDIANS.length === 0 ? null : (
+            <>
+              <Typography variant="subtitle1" sx={{ mt: 2, mb: 1 }}>
+                Standby Guardians
+              </Typography>
+              <Box display="flex" flexWrap="wrap" alignItems="center" justifyContent={'center'}>
+                {standbyHeartbeats.map((hb) => (
+                  <GuardianCard
+                    key={`${hb.guardianAddr}-${hb.nodeName}`}
+                    heartbeat={hb}
+                    highestByChain={highestByChain}
+                    latestRelease={latestRelease}
+                  />
+                ))}
+              </Box>
+            </>
+          )}
         </>
       ) : (
         <>
           <Card>
             <Table<Heartbeat> table={table} showRowCount />
           </Card>
-          <Typography variant="subtitle1" sx={{ mt: 2, mb: 1 }}>
-            Standby Guardians
-          </Typography>
-          <Card>
-            <Table<Heartbeat> table={standbyTable} showRowCount />
-          </Card>
+          {STANDBY_GUARDIANS.length === 0 ? null : (
+            <>
+              <Typography variant="subtitle1" sx={{ mt: 2, mb: 1 }}>
+                Standby Guardians
+              </Typography>
+              <Card>
+                <Table<Heartbeat> table={standbyTable} showRowCount />
+              </Card>
+            </>
+          )}
         </>
       )}
     </CollapsibleSection>

--- a/dashboard/src/hooks/useHeartbeats.ts
+++ b/dashboard/src/hooks/useHeartbeats.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNetworkContext } from '../contexts/NetworkContext';
 import { getLastHeartbeats, Heartbeat } from '../utils/getLastHeartbeats';
+import { GUARDIAN_SET } from '@wormhole-foundation/wormhole-monitor-common';
 
 function useHeartbeats(currentGuardianSet: string | null): Heartbeat[] {
   const { currentNetwork } = useNetworkContext();
@@ -14,6 +15,24 @@ function useHeartbeats(currentGuardianSet: string | null): Heartbeat[] {
       while (!cancelled) {
         const heartbeats = await getLastHeartbeats(currentNetwork, currentGuardianSet);
         if (!cancelled) {
+          // Add placeholder entries for guardians that haven't heartbeated
+          if (currentNetwork.env === 'Mainnet') {
+            const seen = new Set(heartbeats.map((hb) => hb.guardianAddr.toLowerCase()));
+            for (const guardian of GUARDIAN_SET) {
+              if (!seen.has(guardian.pubkey.toLowerCase())) {
+                heartbeats.push({
+                  guardianAddr: guardian.pubkey,
+                  nodeName: guardian.name,
+                  networks: [],
+                  version: '',
+                  counter: '0',
+                  timestamp: '',
+                  bootTimestamp: '',
+                  features: [],
+                });
+              }
+            }
+          }
           setHeartbeats(heartbeats.sort((a, b) => a.nodeName.localeCompare(b.nodeName)));
           await new Promise((resolve) =>
             setTimeout(resolve, currentNetwork.type === 'guardian' ? 1000 : 10000)

--- a/fly/common/consts.go
+++ b/fly/common/consts.go
@@ -17,9 +17,7 @@ type GuardianEntry struct {
 	Address string
 }
 
-var StandbyMainnetGuardians = []GuardianEntry{
-	{19, "Google Cloud", "0x68c16a92903c4c74ffddc730582ba53d967d3dac"},
-}
+var StandbyMainnetGuardians = []GuardianEntry{}
 
 // Although there are multiple testnet guardians running, they all use the same key, so it looks like one.
 var TestnetGuardians = []GuardianEntry{


### PR DESCRIPTION
This PR removes the deprecated Google Cloud standby guardian key, hides the standby guardian sections when there are none, and ensures that all guardians in the set always appear in the lists and counts.