### PR TITLE
Don't unfurl links when sending alerts to slack

### DIFF
--- a/common/src/utils.ts
+++ b/common/src/utils.ts
@@ -100,6 +100,8 @@ export async function formatAndSendToSlack(info: SlackInfo): Promise<any> {
   // Construct the payload
   const payload = {
     channel: info.channelId,
+    // https://docs.slack.dev/messaging/unfurling-links-in-messages
+    unfurl_links: false,
     blocks: [
       {
         type: 'section',


### PR DESCRIPTION
When sending alerts for things like missing VAAs, there are links embedded in the message. By default, slack unfurls them and it makes the output harder to parse when there are multiple missing vaas.

Here are the [Slack docs](https://docs.slack.dev/messaging/unfurling-links-in-messages) with docs on how to disable this.

It currently looks like this: 
<img width="718" height="755" alt="image" src="https://github.com/user-attachments/assets/655538a9-1414-4358-b7eb-b51534dc2c69" />

**NOTE**: this also affects the wormchain monitor cloud function as well, but that is also just text so this should be the correct thing.