### PR TITLE
fix(dashboard): last observation display

### DIFF
--- a/dashboard/src/hooks/useChainHeartbeats.ts
+++ b/dashboard/src/hooks/useChainHeartbeats.ts
@@ -26,6 +26,7 @@ function useChainHeartbeats(heartbeats: Heartbeat[]) {
             height: '0',
             safeHeight: '0',
             finalizedHeight: '0',
+            lastObservationSignedAt: '0',
           },
         }));
       }


### PR DESCRIPTION
fixes that an empty guardian was showing the same time as others
<img width="1225" height="770" alt="image" src="https://github.com/user-attachments/assets/0bc549cb-8d0f-462e-8ef8-a31eb1467c64" />
