### PR TITLE
chore(dashboard): update refresh times

### DIFF
--- a/dashboard/src/components/Accountant.tsx
+++ b/dashboard/src/components/Accountant.tsx
@@ -46,6 +46,7 @@ import { TokenDataByChainAddress, TokenDataEntry } from '../hooks/useTokenData';
 import { CHAIN_ICON_MAP, WORMCHAIN_URL } from '../utils/consts';
 import CollapsibleSection from './CollapsibleSection';
 import { ExplorerTxHash } from './ExplorerTxHash';
+import FetchedAt from './FetchedAt';
 import Table from './Table';
 
 const NTT_ACCOUNTANT_TOKEN_ADDRESS_OVERRIDE: {
@@ -404,11 +405,13 @@ const MemoizedAccountantSearch = memo(AccountantSearch);
 function Accountant({
   governorInfo,
   tokenData,
+  tokenDataReceivedAt,
   accountantAddress,
   isNTT,
 }: {
   governorInfo?: CloudGovernorInfo;
   tokenData: TokenDataByChainAddress | null;
+  tokenDataReceivedAt: string | null;
   accountantAddress: string;
   isNTT?: boolean;
 }) {
@@ -424,9 +427,11 @@ function Accountant({
     setOpen(false);
   }, []);
 
-  const pendingTransferInfo = useGetAccountantPendingTransfers(accountantAddress);
+  const { pendingTransfers: pendingTransferInfo, receivedAt: pendingTransfersReceivedAt } =
+    useGetAccountantPendingTransfers(accountantAddress);
 
-  const accountsInfo = useGetAccountantAccounts(accountantAddress);
+  const { accounts: accountsInfo, receivedAt: accountsReceivedAt } =
+    useGetAccountantAccounts(accountantAddress);
 
   const governorInfoIsDefined = !!governorInfo;
 
@@ -712,6 +717,13 @@ function Accountant({
             </Accordion>
           </Card>
         </Box>
+        <FetchedAt
+          entries={[
+            { label: 'Pending transfers', receivedAt: pendingTransfersReceivedAt },
+            { label: 'Accounts', receivedAt: accountsReceivedAt },
+            { label: 'Tokens', receivedAt: tokenDataReceivedAt },
+          ]}
+        />
       </CollapsibleSection>
       <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
         <DialogTitle>Accountant Transfer Search</DialogTitle>

--- a/dashboard/src/components/FetchedAt.tsx
+++ b/dashboard/src/components/FetchedAt.tsx
@@ -1,0 +1,32 @@
+import { Typography } from '@mui/material';
+
+type Entry = {
+  label: string;
+  receivedAt: string | null;
+  error?: any | null;
+};
+
+function FetchedAt({ entries }: { entries: Entry[] }) {
+  const hasAny = entries.some((e) => e.receivedAt || e.error);
+  if (!hasAny) return null;
+  return (
+    <Typography variant="body2" sx={{ mt: 2, textAlign: 'right' }}>
+      {entries.map((entry, idx) => (
+        <span key={entry.label}>
+          {idx > 0 ? '; ' : ''}
+          {entry.label} fetched{' '}
+          {entry.receivedAt ? new Date(entry.receivedAt).toLocaleString() : '—'}
+          {entry.error ? (
+            <Typography component="span" color="error" variant="body2">
+              {' '}
+              {String(entry.error)}
+            </Typography>
+          ) : null}
+        </span>
+      ))}
+      .
+    </Typography>
+  );
+}
+
+export default FetchedAt;

--- a/dashboard/src/components/Governor.tsx
+++ b/dashboard/src/components/Governor.tsx
@@ -32,6 +32,7 @@ import { useCallback, useMemo, useState } from 'react';
 import useGovernorInfo from '../hooks/useGovernorInfo';
 import { CHAIN_ICON_MAP, WORMHOLE_RPC_HOSTS } from '../utils/consts';
 import CollapsibleSection from './CollapsibleSection';
+import FetchedAt from './FetchedAt';
 import EnqueuedVAAChecker from './EnqueuedVAAChecker';
 import { ExplorerTxHash } from './ExplorerTxHash';
 import Table from './Table';
@@ -330,6 +331,13 @@ function Governor() {
           </Accordion>
         </Card>
       </Box>
+      <FetchedAt
+        entries={[
+          { label: 'Notionals', receivedAt: governorInfo.notionalsReceivedAt },
+          { label: 'Tokens', receivedAt: governorInfo.tokensReceivedAt },
+          { label: 'Enqueued', receivedAt: governorInfo.enqueuedReceivedAt },
+        ]}
+      />
     </CollapsibleSection>
   );
 }

--- a/dashboard/src/components/Guardians.tsx
+++ b/dashboard/src/components/Guardians.tsx
@@ -45,6 +45,7 @@ import { ChainIdToHeartbeats } from '../hooks/useChainHeartbeats';
 import { Heartbeat, HeartbeatNetwork } from '../utils/getLastHeartbeats';
 import { isHeartbeatUnhealthy } from './Chains';
 import CollapsibleSection from './CollapsibleSection';
+import FetchedAt from './FetchedAt';
 import Table from './Table';
 
 const columnHelper = createColumnHelper<Heartbeat>();
@@ -313,10 +314,12 @@ type Displays = 'cards' | 'table';
 
 function Guardians({
   heartbeats,
+  heartbeatsReceivedAt,
   chainIdsToHeartbeats,
   latestRelease,
 }: {
   heartbeats: Heartbeat[];
+  heartbeatsReceivedAt: string | null;
   chainIdsToHeartbeats: ChainIdToHeartbeats;
   latestRelease: string | null;
 }) {
@@ -558,6 +561,7 @@ function Guardians({
           )}
         </>
       )}
+      <FetchedAt entries={[{ label: 'Heartbeats', receivedAt: heartbeatsReceivedAt }]} />
     </CollapsibleSection>
   );
 }

--- a/dashboard/src/components/Home.tsx
+++ b/dashboard/src/components/Home.tsx
@@ -18,22 +18,25 @@ import {
 
 function Home({
   heartbeats,
+  heartbeatsReceivedAt,
   chainIdsToHeartbeats,
   latestRelease,
 }: {
   heartbeats: Heartbeat[];
+  heartbeatsReceivedAt: string | null;
   chainIdsToHeartbeats: ChainIdToHeartbeats;
   latestRelease: string | null;
 }) {
   const { currentNetwork } = useNetworkContext();
   const governorInfo = useCloudGovernorInfo();
-  const tokenData = useTokenData();
+  const { tokenData, receivedAt: tokenDataReceivedAt } = useTokenData();
   return (
     <>
       <Chains chainIdsToHeartbeats={chainIdsToHeartbeats} />
       <Divider />
       <Guardians
         heartbeats={heartbeats}
+        heartbeatsReceivedAt={heartbeatsReceivedAt}
         chainIdsToHeartbeats={chainIdsToHeartbeats}
         latestRelease={latestRelease}
       />
@@ -45,12 +48,14 @@ function Home({
           <Accountant
             governorInfo={governorInfo}
             tokenData={tokenData}
+            tokenDataReceivedAt={tokenDataReceivedAt}
             accountantAddress={ACCOUNTANT_CONTRACT_ADDRESS}
           />
           <Divider />
           <Accountant
             governorInfo={governorInfo}
             tokenData={tokenData}
+            tokenDataReceivedAt={tokenDataReceivedAt}
             accountantAddress={NTT_ACCOUNTANT_CONTRACT_ADDRESS_MAINNET}
             isNTT
           />
@@ -62,6 +67,7 @@ function Home({
           <Accountant
             governorInfo={governorInfo}
             tokenData={tokenData}
+            tokenDataReceivedAt={tokenDataReceivedAt}
             accountantAddress={NTT_ACCOUNTANT_CONTRACT_ADDRESS_TESTNET}
             isNTT
           />

--- a/dashboard/src/components/Home.tsx
+++ b/dashboard/src/components/Home.tsx
@@ -13,7 +13,6 @@ import useTokenData from '../hooks/useTokenData';
 import {
   ACCOUNTANT_CONTRACT_ADDRESS,
   NTT_ACCOUNTANT_CONTRACT_ADDRESS_MAINNET,
-  NTT_ACCOUNTANT_CONTRACT_ADDRESS_TESTNET,
 } from '@wormhole-foundation/wormhole-monitor-common';
 
 function Home({
@@ -63,17 +62,7 @@ function Home({
           <Monitor governorInfo={governorInfo} />
         </>
       ) : currentNetwork.name === 'Testnet' ? (
-        <>
-          <Accountant
-            governorInfo={governorInfo}
-            tokenData={tokenData}
-            tokenDataReceivedAt={tokenDataReceivedAt}
-            accountantAddress={NTT_ACCOUNTANT_CONTRACT_ADDRESS_TESTNET}
-            isNTT
-          />
-          <Divider />
-          <Monitor />
-        </>
+        <Monitor />
       ) : (
         <Governor />
       )}

--- a/dashboard/src/components/Main.tsx
+++ b/dashboard/src/components/Main.tsx
@@ -94,7 +94,7 @@ function Main() {
     'Ethereum',
     contracts.coreBridge(env, 'Ethereum')
   );
-  const heartbeats = useHeartbeats(currentGuardianSet);
+  const { heartbeats, receivedAt: heartbeatsReceivedAt } = useHeartbeats(currentGuardianSet);
   const chainIdsToHeartbeats = useChainHeartbeats(heartbeats);
   const latestRelease = useLatestRelease();
   return (
@@ -133,6 +133,7 @@ function Main() {
         <Route path="/">
           <Home
             heartbeats={heartbeats}
+            heartbeatsReceivedAt={heartbeatsReceivedAt}
             chainIdsToHeartbeats={chainIdsToHeartbeats}
             latestRelease={latestRelease}
           />

--- a/dashboard/src/components/MainnetGovernor.tsx
+++ b/dashboard/src/components/MainnetGovernor.tsx
@@ -42,6 +42,7 @@ import {
 import { CHAIN_ICON_MAP, WORMHOLE_RPC_HOSTS } from '../utils/consts';
 import { getQuorumLossCount } from './Alerts';
 import CollapsibleSection from './CollapsibleSection';
+import FetchedAt from './FetchedAt';
 import EnqueuedVAAChecker from './EnqueuedVAAChecker';
 import { ExplorerTxHash } from './ExplorerTxHash';
 import Table from './Table';
@@ -507,6 +508,12 @@ function MainnetGovernor({ governorInfo }: { governorInfo: CloudGovernorInfo }) 
           </Accordion>
         </Card>
       </Box>
+      <FetchedAt
+        entries={[
+          { label: 'Configs', receivedAt: governorInfo.configsReceivedAt },
+          { label: 'Status', receivedAt: governorInfo.statusReceivedAt },
+        ]}
+      />
     </CollapsibleSection>
   );
 }

--- a/dashboard/src/components/NTTRateLimits.tsx
+++ b/dashboard/src/components/NTTRateLimits.tsx
@@ -15,6 +15,7 @@ import { useNetworkContext } from '../contexts/NetworkContext';
 import { KeyboardArrowDown, KeyboardArrowRight } from '@mui/icons-material';
 import { NTTRateLimit, chainIdToName } from '@wormhole-foundation/wormhole-monitor-common';
 import CollapsibleSection from './CollapsibleSection';
+import FetchedAt from './FetchedAt';
 import { normalizeBigNumber } from '../utils/normalizeBigNumber';
 
 const rateLimitColumnHelper = createColumnHelper<NTTRateLimit>();
@@ -106,7 +107,7 @@ const rateLimitColumns = [
 
 export function NTTRateLimits() {
   const network = useNetworkContext();
-  const rateLimits = useRateLimits(network.currentNetwork);
+  const { rateLimits, receivedAt } = useRateLimits(network.currentNetwork);
   const [rateLimitSorting, setRateLimitSorting] = useState<SortingState>([]);
   const [rateLimitExpanded, setRateLimitExpanded] = useState<ExpandedState>({});
 
@@ -146,6 +147,9 @@ export function NTTRateLimits() {
         <Card>
           <Table<NTTRateLimit> table={table} />
         </Card>
+      </Box>
+      <Box mx={2}>
+        <FetchedAt entries={[{ label: 'Rate limits', receivedAt }]} />
       </Box>
     </CollapsibleSection>
   );

--- a/dashboard/src/components/NTTTotalSupplyAndLocked.tsx
+++ b/dashboard/src/components/NTTTotalSupplyAndLocked.tsx
@@ -16,6 +16,7 @@ import { chainIdToName } from '@wormhole-foundation/wormhole-monitor-common';
 import { useTotalSupplyAndLocked } from '../hooks/useTotalSupplyAndLocked';
 import { NTTTotalSupplyAndLockedData } from '@wormhole-foundation/wormhole-monitor-common';
 import CollapsibleSection from './CollapsibleSection';
+import FetchedAt from './FetchedAt';
 import { normalizeBigNumber } from '../utils/normalizeBigNumber';
 
 const totalSupplyAndLockedColumnHelper = createColumnHelper<NTTTotalSupplyAndLockedData>();
@@ -71,7 +72,7 @@ const rateLimitColumns = [
 
 export function NTTTotalSupplyAndLocked() {
   const network = useNetworkContext();
-  const totalSupplyAndLocked = useTotalSupplyAndLocked(network.currentNetwork);
+  const { totalSupplyAndLocked, receivedAt } = useTotalSupplyAndLocked(network.currentNetwork);
   const [totalSupplyAndLockedSorting, setTotalSupplyAndLockedSorting] = useState<SortingState>([]);
   const [totalSupplyAndLockedExpanded, setTotalSupplyAndLockedExpanded] = useState<ExpandedState>(
     {}
@@ -114,6 +115,9 @@ export function NTTTotalSupplyAndLocked() {
         <Card>
           <Table<NTTTotalSupplyAndLockedData> table={table} />
         </Card>
+      </Box>
+      <Box mx={2}>
+        <FetchedAt entries={[{ label: 'Total supply and locked', receivedAt }]} />
       </Box>
     </CollapsibleSection>
   );

--- a/dashboard/src/hooks/useCloudGovernorInfo.ts
+++ b/dashboard/src/hooks/useCloudGovernorInfo.ts
@@ -46,6 +46,8 @@ export interface CloudGovernorInfo {
   tokens: GovernorToken[];
   enqueuedVAAs: EnqueuedVAA[];
   totalEnqueuedVaas: TotalEnqueuedVaasByGuardianByChain;
+  configsReceivedAt: string | null;
+  statusReceivedAt: string | null;
 }
 
 interface Chain {
@@ -102,6 +104,8 @@ const createEmptyInfo = (): CloudGovernorInfo => ({
   tokens: [],
   enqueuedVAAs: [],
   totalEnqueuedVaas: {},
+  configsReceivedAt: null,
+  statusReceivedAt: null,
 });
 
 type GovernorConfigsInfo = Pick<CloudGovernorInfo, 'notionals' | 'tokens'>;
@@ -269,15 +273,24 @@ const useCloudGovernorInfo = (): CloudGovernorInfo => {
         try {
           if (!configsInfo) {
             configsInfo = await getConfigsInfo(currentNetwork.endpoint);
+            if (!cancelled) {
+              const fetched = configsInfo;
+              setGovernorInfo((info) => ({
+                ...info,
+                ...fetched,
+                configsReceivedAt: new Date().toISOString(),
+              }));
+            }
           }
           const statusInfo = await getStatusInfo(currentNetwork.endpoint);
           if (!cancelled) {
-            setGovernorInfo({ ...configsInfo, ...statusInfo });
+            setGovernorInfo((info) => ({
+              ...info,
+              ...statusInfo,
+              statusReceivedAt: new Date().toISOString(),
+            }));
           }
         } catch (error) {
-          if (!cancelled) {
-            setGovernorInfo(createEmptyInfo());
-          }
           console.error(error);
         }
         if (!cancelled) {

--- a/dashboard/src/hooks/useCloudGovernorInfo.ts
+++ b/dashboard/src/hooks/useCloudGovernorInfo.ts
@@ -95,7 +95,7 @@ interface GovernorStatusResponse {
   governorStatus: GovernorStatus[];
 }
 
-const POLL_INTERVAL_MS = 10 * 1000;
+const POLL_INTERVAL_MS = 60 * 1000;
 
 const createEmptyInfo = (): CloudGovernorInfo => ({
   notionals: [],
@@ -104,11 +104,11 @@ const createEmptyInfo = (): CloudGovernorInfo => ({
   totalEnqueuedVaas: {},
 });
 
-const getInfo = async (endpoint: string): Promise<CloudGovernorInfo> => {
-  const [configs, status] = await Promise.all([
-    axios.get<GovernorConfigsResponse>(`${endpoint}/governor-configs`),
-    axios.get<GovernorStatusResponse>(`${endpoint}/governor-status`),
-  ]);
+type GovernorConfigsInfo = Pick<CloudGovernorInfo, 'notionals' | 'tokens'>;
+type GovernorStatusInfo = Pick<CloudGovernorInfo, 'enqueuedVAAs' | 'totalEnqueuedVaas'>;
+
+const getConfigsInfo = async (endpoint: string): Promise<GovernorConfigsInfo> => {
+  const configs = await axios.get<GovernorConfigsResponse>(`${endpoint}/governor-configs`);
 
   let firstConfig: GovernorConfig | undefined = undefined;
   const availableNotionalByChain: {
@@ -204,6 +204,14 @@ const getInfo = async (endpoint: string): Promise<CloudGovernorInfo> => {
       return entry;
     }) || [];
 
+  notionals.sort((a, b) => (a.chainId < b.chainId ? -1 : a.chainId > b.chainId ? 1 : 0));
+
+  return { notionals, tokens };
+};
+
+const getStatusInfo = async (endpoint: string): Promise<GovernorStatusInfo> => {
+  const status = await axios.get<GovernorStatusResponse>(`${endpoint}/governor-status`);
+
   const vaaById: { [key: string]: EnqueuedVAA } = {};
   const totalEnqueuedVaas: TotalEnqueuedVaasByGuardianByChain = {};
   for (const s of status.data.governorStatus) {
@@ -240,8 +248,6 @@ const getInfo = async (endpoint: string): Promise<CloudGovernorInfo> => {
 
   const enqueuedVAAs = Object.values(vaaById);
   return {
-    notionals,
-    tokens,
     enqueuedVAAs,
     totalEnqueuedVaas,
   };
@@ -258,14 +264,15 @@ const useCloudGovernorInfo = (): CloudGovernorInfo => {
     }
     let cancelled = false;
     (async () => {
+      let configsInfo: GovernorConfigsInfo | undefined;
       while (!cancelled) {
         try {
-          const info = await getInfo(currentNetwork.endpoint);
-          info.notionals.sort((a, b) =>
-            a.chainId < b.chainId ? -1 : a.chainId > b.chainId ? 1 : 0
-          );
+          if (!configsInfo) {
+            configsInfo = await getConfigsInfo(currentNetwork.endpoint);
+          }
+          const statusInfo = await getStatusInfo(currentNetwork.endpoint);
           if (!cancelled) {
-            setGovernorInfo(info);
+            setGovernorInfo({ ...configsInfo, ...statusInfo });
           }
         } catch (error) {
           if (!cancelled) {

--- a/dashboard/src/hooks/useGetAccountantAccounts.ts
+++ b/dashboard/src/hooks/useGetAccountantAccounts.ts
@@ -3,7 +3,6 @@ import { useNetworkContext } from '../contexts/NetworkContext';
 import { TESTNET_WORMCHAIN_URL, WORMCHAIN_URL } from '../utils/consts';
 import { queryContractSmart } from '@wormhole-foundation/wormhole-monitor-common/src/queryContractSmart';
 
-const POLL_INTERVAL_MS = 1 * 60 * 1000;
 const PAGE_LIMIT = 2000; // throws a gas limit error over this
 
 export type Account = {
@@ -15,48 +14,49 @@ export type Account = {
   balance: string;
 };
 
-const useGetAccountantAccounts = (contractAddress: string): Account[] => {
+export type AccountantAccountsResult = {
+  accounts: Account[];
+  receivedAt: string | null;
+};
+
+const useGetAccountantAccounts = (contractAddress: string): AccountantAccountsResult => {
   const { currentNetwork } = useNetworkContext();
-  const [accountantInfo, setAccountantInfo] = useState<Account[]>([]);
+  const [result, setResult] = useState<AccountantAccountsResult>({
+    accounts: [],
+    receivedAt: null,
+  });
 
   useEffect(() => {
+    setResult({ accounts: [], receivedAt: null });
     if (currentNetwork.name !== 'Mainnet' && currentNetwork.name !== 'Testnet') {
       return;
     }
     let cancelled = false;
     (async () => {
-      while (!cancelled) {
-        try {
-          let accounts: Account[] = [];
-          let response;
-          let start_after = undefined;
-          do {
-            response = await queryContractSmart(
-              currentNetwork.name === 'Mainnet' ? WORMCHAIN_URL : TESTNET_WORMCHAIN_URL,
-              contractAddress,
-              {
-                all_accounts: {
-                  limit: PAGE_LIMIT,
-                  start_after,
-                },
-              }
-            );
-            accounts = [...accounts, ...response.accounts];
-            start_after =
-              response.accounts.length && response.accounts[response.accounts.length - 1].key;
-          } while (response.accounts.length === PAGE_LIMIT);
-          if (!cancelled) {
-            setAccountantInfo(accounts);
-          }
-        } catch (error) {
-          if (!cancelled) {
-            setAccountantInfo([]);
-          }
-          console.error(error);
-        }
+      try {
+        let accounts: Account[] = [];
+        let response;
+        let start_after = undefined;
+        do {
+          response = await queryContractSmart(
+            currentNetwork.name === 'Mainnet' ? WORMCHAIN_URL : TESTNET_WORMCHAIN_URL,
+            contractAddress,
+            {
+              all_accounts: {
+                limit: PAGE_LIMIT,
+                start_after,
+              },
+            }
+          );
+          accounts = [...accounts, ...response.accounts];
+          start_after =
+            response.accounts.length && response.accounts[response.accounts.length - 1].key;
+        } while (response.accounts.length === PAGE_LIMIT);
         if (!cancelled) {
-          await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+          setResult({ accounts, receivedAt: new Date().toISOString() });
         }
+      } catch (error) {
+        console.error(error);
       }
     })();
     return () => {
@@ -64,7 +64,7 @@ const useGetAccountantAccounts = (contractAddress: string): Account[] => {
     };
   }, [currentNetwork, contractAddress]);
 
-  return accountantInfo;
+  return result;
 };
 
 export default useGetAccountantAccounts;

--- a/dashboard/src/hooks/useGetAccountantPendingTransfers.ts
+++ b/dashboard/src/hooks/useGetAccountantPendingTransfers.ts
@@ -3,7 +3,7 @@ import { useNetworkContext } from '../contexts/NetworkContext';
 import { TESTNET_WORMCHAIN_URL, WORMCHAIN_URL } from '../utils/consts';
 import { queryContractSmart } from '@wormhole-foundation/wormhole-monitor-common/src/queryContractSmart';
 
-const POLL_INTERVAL_MS = 10 * 1000;
+const POLL_INTERVAL_MS = 60 * 1000;
 const PAGE_LIMIT = 2000; // throws a gas limit error over this
 
 export type PendingTransferKey = {

--- a/dashboard/src/hooks/useGetAccountantPendingTransfers.ts
+++ b/dashboard/src/hooks/useGetAccountantPendingTransfers.ts
@@ -25,9 +25,19 @@ export type PendingTransfer = {
   ];
 };
 
-const useGetAccountantPendingTransfers = (contractAddress: string): PendingTransfer[] => {
+export type AccountantPendingTransfersResult = {
+  pendingTransfers: PendingTransfer[];
+  receivedAt: string | null;
+};
+
+const useGetAccountantPendingTransfers = (
+  contractAddress: string
+): AccountantPendingTransfersResult => {
   const { currentNetwork } = useNetworkContext();
-  const [accountantInfo, setAccountantInfo] = useState<PendingTransfer[]>([]);
+  const [result, setResult] = useState<AccountantPendingTransfersResult>({
+    pendingTransfers: [],
+    receivedAt: null,
+  });
 
   useEffect(() => {
     if (currentNetwork.name !== 'Mainnet' && currentNetwork.name !== 'Testnet') {
@@ -56,11 +66,11 @@ const useGetAccountantPendingTransfers = (contractAddress: string): PendingTrans
               response.pending.length && response.pending[response.pending.length - 1].key;
           } while (response.pending.length === PAGE_LIMIT);
           if (!cancelled) {
-            setAccountantInfo(pending);
+            setResult({ pendingTransfers: pending, receivedAt: new Date().toISOString() });
           }
         } catch (error) {
           if (!cancelled) {
-            setAccountantInfo([]);
+            setResult({ pendingTransfers: [], receivedAt: null });
           }
           console.error(error);
         }
@@ -74,7 +84,7 @@ const useGetAccountantPendingTransfers = (contractAddress: string): PendingTrans
     };
   }, [currentNetwork, contractAddress]);
 
-  return accountantInfo;
+  return result;
 };
 
 export default useGetAccountantPendingTransfers;

--- a/dashboard/src/hooks/useGovernorInfo.ts
+++ b/dashboard/src/hooks/useGovernorInfo.ts
@@ -22,7 +22,7 @@ const createEmptyInfo = (): GovernorInfo => ({
   enqueued: [],
 });
 
-const TIMEOUT = 10 * 1000;
+const TIMEOUT = 60 * 1000;
 
 function useGovernorInfo(): GovernorInfo {
   const { currentNetwork } = useNetworkContext();

--- a/dashboard/src/hooks/useGovernorInfo.ts
+++ b/dashboard/src/hooks/useGovernorInfo.ts
@@ -14,12 +14,18 @@ type GovernorInfo = {
   notionals: GovernorGetAvailableNotionalByChainResponse_Entry[];
   tokens: GovernorGetTokenListResponse_Entry[];
   enqueued: GovernorGetEnqueuedVAAsResponse_Entry[];
+  notionalsReceivedAt: string | null;
+  tokensReceivedAt: string | null;
+  enqueuedReceivedAt: string | null;
 };
 
 const createEmptyInfo = (): GovernorInfo => ({
   notionals: [],
   tokens: [],
   enqueued: [],
+  notionalsReceivedAt: null,
+  tokensReceivedAt: null,
+  enqueuedReceivedAt: null,
 });
 
 const TIMEOUT = 60 * 1000;
@@ -36,7 +42,11 @@ function useGovernorInfo(): GovernorInfo {
       while (!cancelled && currentNetwork.type === 'guardian') {
         const response = await getGovernorAvailableNotionalByChain(currentNetwork);
         if (!cancelled) {
-          setGovernorInfo((info) => ({ ...info, notionals: response.entries }));
+          setGovernorInfo((info) => ({
+            ...info,
+            notionals: response.entries,
+            notionalsReceivedAt: new Date().toISOString(),
+          }));
           await new Promise((resolve) => setTimeout(resolve, TIMEOUT));
         }
       }
@@ -66,6 +76,7 @@ function useGovernorInfo(): GovernorInfo {
               } catch (e) {}
               return entry;
             }),
+            tokensReceivedAt: new Date().toISOString(),
           }));
           await new Promise((resolve) => setTimeout(resolve, TIMEOUT));
         }
@@ -81,7 +92,11 @@ function useGovernorInfo(): GovernorInfo {
       while (!cancelled && currentNetwork.type === 'guardian') {
         const response = await getGovernorEnqueuedVAAs(currentNetwork);
         if (!cancelled) {
-          setGovernorInfo((info) => ({ ...info, enqueued: response.entries }));
+          setGovernorInfo((info) => ({
+            ...info,
+            enqueued: response.entries,
+            enqueuedReceivedAt: new Date().toISOString(),
+          }));
           await new Promise((resolve) => setTimeout(resolve, TIMEOUT));
         }
       }

--- a/dashboard/src/hooks/useHeartbeats.ts
+++ b/dashboard/src/hooks/useHeartbeats.ts
@@ -3,11 +3,16 @@ import { useNetworkContext } from '../contexts/NetworkContext';
 import { getLastHeartbeats, Heartbeat } from '../utils/getLastHeartbeats';
 import { GUARDIAN_SET } from '@wormhole-foundation/wormhole-monitor-common';
 
-function useHeartbeats(currentGuardianSet: string | null): Heartbeat[] {
+export type HeartbeatsResult = {
+  heartbeats: Heartbeat[];
+  receivedAt: string | null;
+};
+
+function useHeartbeats(currentGuardianSet: string | null): HeartbeatsResult {
   const { currentNetwork } = useNetworkContext();
-  const [heartbeats, setHeartbeats] = useState<Heartbeat[]>([]);
+  const [result, setResult] = useState<HeartbeatsResult>({ heartbeats: [], receivedAt: null });
   useEffect(() => {
-    setHeartbeats([]);
+    setResult({ heartbeats: [], receivedAt: null });
   }, [currentNetwork, currentGuardianSet]);
   useEffect(() => {
     let cancelled = false;
@@ -33,7 +38,10 @@ function useHeartbeats(currentGuardianSet: string | null): Heartbeat[] {
               }
             }
           }
-          setHeartbeats(heartbeats.sort((a, b) => a.nodeName.localeCompare(b.nodeName)));
+          setResult({
+            heartbeats: heartbeats.sort((a, b) => a.nodeName.localeCompare(b.nodeName)),
+            receivedAt: new Date().toISOString(),
+          });
           await new Promise((resolve) =>
             setTimeout(resolve, currentNetwork.type === 'guardian' ? 15000 : 30000)
           );
@@ -44,6 +52,6 @@ function useHeartbeats(currentGuardianSet: string | null): Heartbeat[] {
       cancelled = true;
     };
   }, [currentNetwork, currentGuardianSet]);
-  return heartbeats;
+  return result;
 }
 export default useHeartbeats;

--- a/dashboard/src/hooks/useHeartbeats.ts
+++ b/dashboard/src/hooks/useHeartbeats.ts
@@ -35,7 +35,7 @@ function useHeartbeats(currentGuardianSet: string | null): Heartbeat[] {
           }
           setHeartbeats(heartbeats.sort((a, b) => a.nodeName.localeCompare(b.nodeName)));
           await new Promise((resolve) =>
-            setTimeout(resolve, currentNetwork.type === 'guardian' ? 1000 : 10000)
+            setTimeout(resolve, currentNetwork.type === 'guardian' ? 15000 : 30000)
           );
         }
       }

--- a/dashboard/src/hooks/useRateLimits.ts
+++ b/dashboard/src/hooks/useRateLimits.ts
@@ -3,16 +3,12 @@ import { Network } from '../contexts/NetworkContext';
 import { NTTRateLimit } from '@wormhole-foundation/wormhole-monitor-common';
 import axios from 'axios';
 
-const REFRESH_INTERVAL = 120_000; // 2 minutes
-
 export function useRateLimits(network: Network) {
   const [rateLimits, setRateLimits] = useState<NTTRateLimit[]>([]);
 
   useEffect(() => {
     let cancelled = false;
-
-    const fetchRateLimits = async () => {
-      if (cancelled) return;
+    (async () => {
       const response = await axios.post<NTTRateLimit[]>(
         `${network.endpoint}/get-ntt-rate-limits`,
         {},
@@ -27,20 +23,9 @@ export function useRateLimits(network: Network) {
           },
         }
       );
-
       if (cancelled || !response.data) return;
       setRateLimits(response.data);
-    };
-
-    const startAutoRefresh = async () => {
-      while (!cancelled) {
-        await fetchRateLimits();
-        await new Promise((resolve) => setTimeout(resolve, REFRESH_INTERVAL));
-      }
-    };
-
-    startAutoRefresh();
-
+    })();
     return () => {
       cancelled = true;
     };

--- a/dashboard/src/hooks/useRateLimits.ts
+++ b/dashboard/src/hooks/useRateLimits.ts
@@ -3,8 +3,13 @@ import { Network } from '../contexts/NetworkContext';
 import { NTTRateLimit } from '@wormhole-foundation/wormhole-monitor-common';
 import axios from 'axios';
 
-export function useRateLimits(network: Network) {
-  const [rateLimits, setRateLimits] = useState<NTTRateLimit[]>([]);
+export type RateLimitsResult = {
+  rateLimits: NTTRateLimit[];
+  receivedAt: string | null;
+};
+
+export function useRateLimits(network: Network): RateLimitsResult {
+  const [result, setResult] = useState<RateLimitsResult>({ rateLimits: [], receivedAt: null });
 
   useEffect(() => {
     let cancelled = false;
@@ -24,12 +29,12 @@ export function useRateLimits(network: Network) {
         }
       );
       if (cancelled || !response.data) return;
-      setRateLimits(response.data);
+      setResult({ rateLimits: response.data, receivedAt: new Date().toISOString() });
     })();
     return () => {
       cancelled = true;
     };
   }, [network]);
 
-  return rateLimits;
+  return result;
 }

--- a/dashboard/src/hooks/useTokenData.ts
+++ b/dashboard/src/hooks/useTokenData.ts
@@ -26,19 +26,16 @@ function useTokenData(): TokenDataByChainAddress | null {
     if (skip) return;
     let cancelled = false;
     (async () => {
-      while (!cancelled) {
-        const response = await axios.get<{ data: TokenDataEntry[] }>(
-          `${currentNetwork.endpoint}/latest-tokendata`
+      const response = await axios.get<{ data: TokenDataEntry[] }>(
+        `${currentNetwork.endpoint}/latest-tokendata`
+      );
+      if (!cancelled) {
+        setTokenData(
+          response.data?.data.reduce<TokenDataByChainAddress>((obj, tokenData) => {
+            obj[`${tokenData.token_chain}/${tokenData.token_address}`] = tokenData;
+            return obj;
+          }, {}) || null
         );
-        if (!cancelled) {
-          setTokenData(
-            response.data?.data.reduce<TokenDataByChainAddress>((obj, tokenData) => {
-              obj[`${tokenData.token_chain}/${tokenData.token_address}`] = tokenData;
-              return obj;
-            }, {}) || null
-          );
-          await new Promise((resolve) => setTimeout(resolve, 60000));
-        }
       }
     })();
     return () => {

--- a/dashboard/src/hooks/useTokenData.ts
+++ b/dashboard/src/hooks/useTokenData.ts
@@ -17,12 +17,17 @@ export type TokenDataByChainAddress = {
   [chainAddress: string]: TokenDataEntry;
 };
 
-function useTokenData(): TokenDataByChainAddress | null {
+export type TokenDataResult = {
+  tokenData: TokenDataByChainAddress | null;
+  receivedAt: string | null;
+};
+
+function useTokenData(): TokenDataResult {
   const { currentNetwork } = useNetworkContext();
   const skip = currentNetwork.type !== 'cloudfunction';
-  const [tokenData, setTokenData] = useState<TokenDataByChainAddress | null>(null);
+  const [result, setResult] = useState<TokenDataResult>({ tokenData: null, receivedAt: null });
   useEffect(() => {
-    setTokenData(null);
+    setResult({ tokenData: null, receivedAt: null });
     if (skip) return;
     let cancelled = false;
     (async () => {
@@ -30,18 +35,20 @@ function useTokenData(): TokenDataByChainAddress | null {
         `${currentNetwork.endpoint}/latest-tokendata`
       );
       if (!cancelled) {
-        setTokenData(
-          response.data?.data.reduce<TokenDataByChainAddress>((obj, tokenData) => {
-            obj[`${tokenData.token_chain}/${tokenData.token_address}`] = tokenData;
-            return obj;
-          }, {}) || null
-        );
+        setResult({
+          tokenData:
+            response.data?.data.reduce<TokenDataByChainAddress>((obj, tokenData) => {
+              obj[`${tokenData.token_chain}/${tokenData.token_address}`] = tokenData;
+              return obj;
+            }, {}) || null,
+          receivedAt: new Date().toISOString(),
+        });
       }
     })();
     return () => {
       cancelled = true;
     };
   }, [currentNetwork, skip]);
-  return tokenData;
+  return result;
 }
 export default useTokenData;

--- a/dashboard/src/hooks/useTotalSupplyAndLocked.ts
+++ b/dashboard/src/hooks/useTotalSupplyAndLocked.ts
@@ -3,8 +3,6 @@ import { Network } from '../contexts/NetworkContext';
 import { NTTTotalSupplyAndLockedData } from '@wormhole-foundation/wormhole-monitor-common';
 import axios from 'axios';
 
-const REFRESH_INTERVAL = 120_000; // 2 minutes
-
 export function useTotalSupplyAndLocked(network: Network) {
   const [totalSupplyAndLocked, setTotalSupplyAndLocked] = useState<NTTTotalSupplyAndLockedData[]>(
     []
@@ -12,26 +10,14 @@ export function useTotalSupplyAndLocked(network: Network) {
 
   useEffect(() => {
     let cancelled = false;
-
-    const fetchTotalSupplyAndLocked = async () => {
-      if (cancelled) return;
+    (async () => {
       const response = await axios.post<NTTTotalSupplyAndLockedData[]>(
         `${network.endpoint}/get-total-supply-and-locked`
       );
       if (!cancelled && response.data) {
         setTotalSupplyAndLocked(response.data);
       }
-    };
-
-    const startAutoRefresh = async () => {
-      while (!cancelled) {
-        await fetchTotalSupplyAndLocked();
-        await new Promise((resolve) => setTimeout(resolve, REFRESH_INTERVAL));
-      }
-    };
-
-    startAutoRefresh();
-
+    })();
     return () => {
       cancelled = true;
     };

--- a/dashboard/src/hooks/useTotalSupplyAndLocked.ts
+++ b/dashboard/src/hooks/useTotalSupplyAndLocked.ts
@@ -3,10 +3,16 @@ import { Network } from '../contexts/NetworkContext';
 import { NTTTotalSupplyAndLockedData } from '@wormhole-foundation/wormhole-monitor-common';
 import axios from 'axios';
 
-export function useTotalSupplyAndLocked(network: Network) {
-  const [totalSupplyAndLocked, setTotalSupplyAndLocked] = useState<NTTTotalSupplyAndLockedData[]>(
-    []
-  );
+export type TotalSupplyAndLockedResult = {
+  totalSupplyAndLocked: NTTTotalSupplyAndLockedData[];
+  receivedAt: string | null;
+};
+
+export function useTotalSupplyAndLocked(network: Network): TotalSupplyAndLockedResult {
+  const [result, setResult] = useState<TotalSupplyAndLockedResult>({
+    totalSupplyAndLocked: [],
+    receivedAt: null,
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -15,7 +21,10 @@ export function useTotalSupplyAndLocked(network: Network) {
         `${network.endpoint}/get-total-supply-and-locked`
       );
       if (!cancelled && response.data) {
-        setTotalSupplyAndLocked(response.data);
+        setResult({
+          totalSupplyAndLocked: response.data,
+          receivedAt: new Date().toISOString(),
+        });
       }
     })();
     return () => {
@@ -23,5 +32,5 @@ export function useTotalSupplyAndLocked(network: Network) {
     };
   }, [network]);
 
-  return totalSupplyAndLocked;
+  return result;
 }


### PR DESCRIPTION
## Fetch interval changes

| Source | Before | After |
|---|---|---|
| Monitor `/latest-blocks` | 60s | 60s (unchanged) |
| Monitor `/missing-vaas` | 60s | 60s (unchanged) |
| Heartbeats (guardian) | 1s | **15s** |
| Heartbeats (cloudfunction) | 10s | **30s** |
| Governor (guardian) — notionals | 10s | **60s** |
| Governor (guardian) — tokens | 10s | **60s** |
| Governor (guardian) — enqueued | 10s | **60s** |
| Cloud governor `/governor-configs` | 10s | **once** (on network change) |
| Cloud governor `/governor-status` | 10s | **60s** |
| Accountant pending transfers | 10s | **60s** |
| Accountant accounts | 60s | **once** (on network/address change) |
| Token data `/latest-tokendata` | 60s | **once** (on network change) |
| NTT total supply & locked | 120s | **once** (on network change) |
| NTT rate limits | 120s | **once** (on network change) |
| Latest GitHub release | 60s | 60s (unchanged) |
| EnqueuedVAAChecker (per-VAA, until quorum) | 60s | 60s (unchanged) |

The two aggressive loops (guardian heartbeats at 1s, governor/accountant at 10s) now poll at 15–60s, and five heavier endpoints (cloud governor configs, accountant accounts, token data, NTT total supply, NTT rate limits) no longer poll — they fetch once and refresh only when the network (or contract address) changes.

Each section also displays a "fetched at" indicator showing the last successful fetch time per data source, matching the existing pattern in the Monitor section.
