### PR TITLE
watcher: upgrade sui sdk and use graphql and grpc for the watcher implementation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,13 +3,17 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -18,7 +22,7 @@ jobs:
           npm ci
           npm run build:dashboard
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: dashboard/dist # The folder the action should deploy.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,6 +48,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.23
+          go-version: 1.24
       - name: Build
         run: cd fly && go build -v ./...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,14 +1,18 @@
 name: Test
 on:
   pull_request:
+permissions:
+  contents: read
+  pull-requests: read
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive # Initialize submodules recursively
-      - uses: actions/setup-node@v3
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -26,10 +30,11 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive # Initialize submodules recursively
-      - uses: actions/setup-node@v3
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       - run: npm  ci
@@ -37,9 +42,11 @@ jobs:
   build-fly:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.23
       - name: Build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,9 +23,9 @@ jobs:
       - run: npm run build -w dashboard
       - name: Run tests
         env:
-          ETH_RPC: ${{ secrets.ETH_RPC }}
-          SOLANA_RPC: ${{ secrets.SOLANA_RPC }}
-          NEAR_ARCHIVE_RPC: ${{ secrets.NEAR_ARCHIVE_RPC }}
+          ETH_RPC: ${{ secrets.ETH_RPC }} # zizmor: ignore[secrets-outside-env]
+          SOLANA_RPC: ${{ secrets.SOLANA_RPC }} # zizmor: ignore[secrets-outside-env]
+          NEAR_ARCHIVE_RPC: ${{ secrets.NEAR_ARCHIVE_RPC }} # zizmor: ignore[secrets-outside-env]
         run: npm run test --workspaces --if-present
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ permissions:
   pull-requests: read
 jobs:
   test-and-build:
+    environment: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -23,9 +24,9 @@ jobs:
       - run: npm run build -w dashboard
       - name: Run tests
         env:
-          ETH_RPC: ${{ secrets.ETH_RPC }} # zizmor: ignore[secrets-outside-env]
-          SOLANA_RPC: ${{ secrets.SOLANA_RPC }} # zizmor: ignore[secrets-outside-env]
-          NEAR_ARCHIVE_RPC: ${{ secrets.NEAR_ARCHIVE_RPC }} # zizmor: ignore[secrets-outside-env]
+          ETH_RPC: ${{ secrets.ETH_RPC }}
+          SOLANA_RPC: ${{ secrets.SOLANA_RPC }}
+          NEAR_ARCHIVE_RPC: ${{ secrets.NEAR_ARCHIVE_RPC }}
         run: npm run test --workspaces --if-present
   format:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -379,7 +379,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.6.tgz",
       "integrity": "sha512-qAHSfAdVyFmIvl0VHELib8xar7ONuSHrE2hLnsaWkYNTI68dmi1x8GYDhJjMI/e7XWal9QBlZkwbOnkcw7Z8gQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.6",
@@ -1199,7 +1198,6 @@
       "integrity": "sha512-gNkksSdV8RbsCoHF9sjVYrHfYACMl/8U32UfUhJ9+84/ASXw8dlx+eHyyF0m6ncQJ9IBSxfuCkB36GJqYdXTOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.6"
       },
@@ -2095,7 +2093,6 @@
       "integrity": "sha512-pCtPHhpRZHfwdA5G1Gpk5mIzMA99hv0R8S/Ket50Rw+S+8hkt3wBWqdqHaPw0CuUYxdshUgsPiLQ5fAs4ASMhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.24.6",
         "@babel/helper-module-imports": "^7.24.6",
@@ -3270,7 +3267,6 @@
       "version": "11.11.4",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
       "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -3311,7 +3307,6 @@
       "version": "11.11.5",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
       "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -3868,6 +3863,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -3894,6 +3890,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -3918,6 +3915,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -3940,6 +3938,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -3962,6 +3961,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0"
       }
@@ -3980,6 +3980,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/properties": "^5.7.0"
@@ -3999,6 +4000,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -4037,6 +4039,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0"
       }
@@ -4055,6 +4058,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/abstract-provider": "^5.7.0",
@@ -4082,6 +4086,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -4108,6 +4113,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/basex": "^5.7.0",
@@ -4137,6 +4143,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -4167,6 +4174,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
@@ -4201,6 +4209,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
       }
@@ -4219,6 +4228,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/sha2": "^5.7.0"
@@ -4238,6 +4248,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
       }
@@ -4256,6 +4267,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -4282,12 +4294,14 @@
     "node_modules/@ethersproject/providers/node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "peer": true
     },
     "node_modules/@ethersproject/providers/node_modules/ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -4318,6 +4332,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
@@ -4337,6 +4352,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
@@ -4356,6 +4372,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -4376,6 +4393,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -4389,6 +4407,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "peer": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -4402,7 +4421,8 @@
     "node_modules/@ethersproject/signing-key/node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "peer": true
     },
     "node_modules/@ethersproject/solidity": {
       "version": "5.7.0",
@@ -4418,6 +4438,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -4441,6 +4462,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/constants": "^5.7.0",
@@ -4461,6 +4483,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -4487,6 +4510,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/constants": "^5.7.0",
@@ -4507,6 +4531,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -4539,6 +4564,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/base64": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -4561,6 +4587,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/hash": "^5.7.0",
@@ -4945,7 +4972,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web/-/grpc-web-0.0.1.tgz",
       "integrity": "sha512-Pu5YgaZp+OvR5UWfqbrPdHer3+gDf+b5fQoY+t2VZx1IAVHX8bzbN9EreYTvTYtFeDpYRWM8P7app2u4EX5wTw==",
-      "peer": true,
       "dependencies": {
         "browser-headers": "^0.4.1"
       },
@@ -5878,7 +5904,6 @@
       "version": "5.15.19",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.19.tgz",
       "integrity": "sha512-lp5xQBbcRuxNtjpWU0BWZgIrv2XLUz4RJ0RqFXBdESIsKoGCQZ6P3wwU5ZPuj5TjssNiKv9AlM+vHopRxZhvVQ==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/base": "5.0.0-beta.40",
@@ -6066,12 +6091,12 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/@mysten/bcs": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.7.0.tgz",
-      "integrity": "sha512-8zE2Jzj2ai55RlVXx2pEMbbq+X3vB+uPGBvZr0F79IdTwuwcu4QdFG3PT/zHsytsvATkn+z0f2YDWhM5916u2A==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.9.2.tgz",
+      "integrity": "sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mysten/utils": "0.1.1",
+        "@mysten/utils": "0.2.0",
         "@scure/base": "^1.2.6"
       }
     },
@@ -6085,26 +6110,44 @@
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.37.4",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.37.4.tgz",
-      "integrity": "sha512-3dKddNEF7XTfPnYIfVyHHTX+9fraQrKFxiBJ8nveISqo4skyClH/nDyS8Nkh7coknbWghuSSsD82liCOZX2uLw==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.45.2.tgz",
+      "integrity": "sha512-gftf7fNpFSiXyfXpbtP2afVEnhc7p2m/MEYc/SO5pov92dacGKOpQIF7etZsGDI1Wvhv+dpph+ulRNpnYSs7Bg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "1.7.0",
-        "@mysten/utils": "0.1.1",
-        "@noble/curves": "^1.9.4",
+        "@mysten/bcs": "1.9.2",
+        "@mysten/utils": "0.2.0",
+        "@noble/curves": "=1.9.4",
         "@noble/hashes": "^1.8.0",
+        "@protobuf-ts/grpcweb-transport": "^2.11.1",
+        "@protobuf-ts/runtime": "^2.11.1",
+        "@protobuf-ts/runtime-rpc": "^2.11.1",
         "@scure/base": "^1.2.6",
         "@scure/bip32": "^1.7.0",
         "@scure/bip39": "^1.6.0",
-        "gql.tada": "^1.8.12",
+        "gql.tada": "^1.8.13",
         "graphql": "^16.11.0",
-        "poseidon-lite": "^0.2.0",
-        "valibot": "^0.36.0"
+        "poseidon-lite": "0.2.1",
+        "valibot": "^1.2.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@mysten/sui/node_modules/@noble/curves": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
+      "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@mysten/sui/node_modules/@scure/base": {
@@ -6117,9 +6160,9 @@
       }
     },
     "node_modules/@mysten/utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.1.1.tgz",
-      "integrity": "sha512-jvhJC6/2la1QHltukQXzfyTZ+VVHxe187JjPx+mEXRUWyAo6jCSdioOQJIfaGu4K4i+37KeiydXRwV/bq/7UJQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.2.0.tgz",
+      "integrity": "sha512-CM6kJcJHX365cK6aXfFRLBiuyXc5WSBHQ43t94jqlCAIRw8umgNcTb5EnEA9n31wPAQgLDGgbG/rCUISCTJ66w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.2.6"
@@ -6489,6 +6532,31 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@protobuf-ts/grpcweb-transport": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/grpcweb-transport/-/grpcweb-transport-2.11.1.tgz",
+      "integrity": "sha512-1W4utDdvOB+RHMFQ0soL4JdnxjXV+ddeGIUg08DvZrA8Ms6k5NN6GBFU2oHZdTOcJVpPrDJ02RJlqtaoCMNBtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.11.1",
+        "@protobuf-ts/runtime-rpc": "^2.11.1"
+      }
+    },
+    "node_modules/@protobuf-ts/runtime": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.11.1.tgz",
+      "integrity": "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@protobuf-ts/runtime-rpc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.11.1.tgz",
+      "integrity": "sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.11.1"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -6844,6 +6912,7 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7123,7 +7192,6 @@
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
       "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -7588,6 +7656,7 @@
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -7630,6 +7699,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.1.0.tgz",
       "integrity": "sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -7648,6 +7718,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -7663,6 +7734,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7671,6 +7743,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7933,6 +8006,7 @@
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -8005,7 +8079,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
@@ -8251,6 +8326,7 @@
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -8275,7 +8351,6 @@
       "version": "18.19.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.33.tgz",
       "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -8323,7 +8398,6 @@
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -8380,6 +8454,7 @@
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -8478,7 +8553,6 @@
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -8534,7 +8608,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -9983,7 +10056,6 @@
       "version": "1.91.7",
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.91.7.tgz",
       "integrity": "sha512-HqljZKDwk6Z4TajKRGhGLlRsbGK4S8EY27DA7v1z6yakewiUY3J7ZKDZRxcqz2MYV/ZXRrJ6wnnpiHFkPdv0WA==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.4",
         "@noble/curves": "^1.4.0",
@@ -10408,7 +10480,8 @@
     "node_modules/aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "peer": true
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -11057,7 +11130,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -11455,7 +11527,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -11607,6 +11678,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.6.0"
       }
@@ -11616,6 +11688,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -11634,6 +11707,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -11827,6 +11901,7 @@
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -12262,6 +12337,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -12277,6 +12353,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12365,6 +12442,7 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12969,7 +13047,6 @@
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -14684,8 +14761,7 @@
     "node_modules/google-protobuf": {
       "version": "3.21.2",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
-      "peer": true
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -14761,7 +14837,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -14942,7 +15017,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/http-errors": {
       "version": "1.8.1",
@@ -14995,6 +15071,7 @@
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -15847,7 +15924,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -17852,6 +17928,7 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18101,6 +18178,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -18320,6 +18398,7 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18720,6 +18799,7 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -19061,7 +19141,6 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
       "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -19213,6 +19292,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -19291,6 +19371,7 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -19355,7 +19436,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19367,7 +19447,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -19720,7 +19799,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -19770,6 +19850,7 @@
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -19903,7 +19984,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
       "integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -21020,7 +21100,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -21290,7 +21369,6 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21515,9 +21593,18 @@
       "dev": true
     },
     "node_modules/valibot": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.36.0.tgz",
-      "integrity": "sha512-CjF1XN4sUce8sBK9TixrDqFM7RwNkuXdJu174/AwmQUB62QbCQADg5lLe8ldBalFgtj1uKj+pKwDJiNo4Mn+eQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.0.tgz",
+      "integrity": "sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -21612,7 +21699,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.12.tgz",
       "integrity": "sha512-/gC8GxzxMK5ntBwb48pR32GGhENnjtY30G4A0jemunsBkiEZFw60s8InGpN8gkhHEkjnRK1aSAxeQgwvFhUHAA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.20.1",
         "postcss": "^8.4.38",
@@ -21966,7 +22052,6 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -22129,7 +22214,7 @@
         "@certusone/wormhole-spydk": "^0.0.1",
         "@coral-xyz/anchor": "0.30.0",
         "@coral-xyz/spl-token": "^0.30.0",
-        "@mysten/sui": "^1.21.2",
+        "@mysten/sui": "1.45.2",
         "@solana/spl-token": "^0.4.6",
         "@solana/web3.js": "^1.73.0",
         "@types/bn.js": "^5.1.0",

--- a/watcher/.env.sample
+++ b/watcher/.env.sample
@@ -1,6 +1,7 @@
 LOG_DIR=.
 LOG_LEVEL=info
-
+NETWORK=mainnet
+MODE=vaa
 ETH_RPC=
 DB_SOURCE=
 JSON_DB_FILE=

--- a/watcher/package.json
+++ b/watcher/package.json
@@ -20,7 +20,7 @@
     "@certusone/wormhole-spydk": "^0.0.1",
     "@coral-xyz/anchor": "0.30.0",
     "@coral-xyz/spl-token": "^0.30.0",
-    "@mysten/sui": "^1.21.2",
+    "@mysten/sui": "1.45.2",
     "@solana/spl-token": "^0.4.6",
     "@solana/web3.js": "^1.73.0",
     "@types/bn.js": "^5.1.0",

--- a/watcher/src/consts.ts
+++ b/watcher/src/consts.ts
@@ -195,14 +195,14 @@ export const GUARDIAN_RPC_HOSTS: { [key in Network]: string[] } = {
 };
 
 export const SUI_GRAPHQL_URLS: { [key in Network]: string } = {
-  'Mainnet': process.env.SUI_GRAPHQL_URL ?? 'https://graphql.mainnet.sui.io/graphql',
-  'Testnet': process.env.SUI_GRAPHQL_URL ?? 'https://graphql.testnet.sui.io/graphql',
-  'Devnet': process.env.SUI_GRAPHQL_URL ?? 'https://graphql.devnet.sui.io/graphql',
+  Mainnet: process.env.SUI_GRAPHQL_URL ?? 'https://graphql.mainnet.sui.io/graphql',
+  Testnet: process.env.SUI_GRAPHQL_URL ?? 'https://graphql.testnet.sui.io/graphql',
+  Devnet: process.env.SUI_GRAPHQL_URL ?? 'https://graphql.devnet.sui.io/graphql',
 };
 export const SUI_GRPC_URLS: { [key in Network]: string } = {
-  'Mainnet': process.env.SUI_GRPC_URL ?? 'https://rpc.mainnet.sui.io:443',
-  'Testnet': process.env.SUI_GRPC_URL ?? 'https://rpc.testnet.sui.io:443',
-  'Devnet': process.env.SUI_GRPC_URL ?? 'https://rpc.devnet.sui.io:443',
+  Mainnet: process.env.SUI_GRPC_URL ?? 'https://rpc.mainnet.sui.io:443',
+  Testnet: process.env.SUI_GRPC_URL ?? 'https://rpc.testnet.sui.io:443',
+  Devnet: process.env.SUI_GRPC_URL ?? 'https://rpc.devnet.sui.io:443',
 };
 
 export type AlgorandInfo = {

--- a/watcher/src/consts.ts
+++ b/watcher/src/consts.ts
@@ -194,6 +194,17 @@ export const GUARDIAN_RPC_HOSTS: { [key in Network]: string[] } = {
   ['Devnet']: [],
 };
 
+export const SUI_GRAPHQL_URLS: { [key in Network]: string } = {
+  'Mainnet': process.env.SUI_GRAPHQL_URL ?? 'https://graphql.mainnet.sui.io/graphql',
+  'Testnet': process.env.SUI_GRAPHQL_URL ?? 'https://graphql.testnet.sui.io/graphql',
+  'Devnet': process.env.SUI_GRAPHQL_URL ?? 'https://graphql.devnet.sui.io/graphql',
+};
+export const SUI_GRPC_URLS: { [key in Network]: string } = {
+  'Mainnet': process.env.SUI_GRPC_URL ?? 'rpc.mainnet.sui.io:443',
+  'Testnet': process.env.SUI_GRPC_URL ?? 'rpc.testnet.sui.io:443',
+  'Devnet': process.env.SUI_GRPC_URL ?? 'rpc.devnet.sui.io:443',
+};
+
 export type AlgorandInfo = {
   appid: number;
   algodToken: string;

--- a/watcher/src/consts.ts
+++ b/watcher/src/consts.ts
@@ -200,9 +200,9 @@ export const SUI_GRAPHQL_URLS: { [key in Network]: string } = {
   'Devnet': process.env.SUI_GRAPHQL_URL ?? 'https://graphql.devnet.sui.io/graphql',
 };
 export const SUI_GRPC_URLS: { [key in Network]: string } = {
-  'Mainnet': process.env.SUI_GRPC_URL ?? 'rpc.mainnet.sui.io:443',
-  'Testnet': process.env.SUI_GRPC_URL ?? 'rpc.testnet.sui.io:443',
-  'Devnet': process.env.SUI_GRPC_URL ?? 'rpc.devnet.sui.io:443',
+  'Mainnet': process.env.SUI_GRPC_URL ?? 'https://rpc.mainnet.sui.io:443',
+  'Testnet': process.env.SUI_GRPC_URL ?? 'https://rpc.testnet.sui.io:443',
+  'Devnet': process.env.SUI_GRPC_URL ?? 'https://rpc.devnet.sui.io:443',
 };
 
 export type AlgorandInfo = {

--- a/watcher/src/watchers/SuiWatcher.ts
+++ b/watcher/src/watchers/SuiWatcher.ts
@@ -1,6 +1,6 @@
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { SuiGraphQLClient } from '@mysten/sui/graphql';
-import { RPCS_BY_CHAIN, SUI_GRAPHQL_URLS, SUI_GRPC_URLS } from '../consts';
+import { SUI_GRAPHQL_URLS, SUI_GRPC_URLS } from '../consts';
 import { VaasByBlock } from '../databases/types';
 import { Watcher } from './Watcher';
 import { makeBlockKey, makeVaaKey } from '../databases/utils';

--- a/watcher/src/watchers/SuiWatcher.ts
+++ b/watcher/src/watchers/SuiWatcher.ts
@@ -43,7 +43,10 @@ type FetchEventsResponse<T = any> = {
   events: EventData<T>[];
   pagination: Pagination;
 };
-type SuccessfulGetTransactionResult = Extract<GetTransactionResult['result'], { oneofKind: 'transaction' }>;
+type SuccessfulGetTransactionResult = Extract<
+  GetTransactionResult['result'],
+  { oneofKind: 'transaction' }
+>;
 
 export class SuiWatcher extends Watcher {
   graphql: SuiGraphQLClient;
@@ -52,15 +55,21 @@ export class SuiWatcher extends Watcher {
 
   constructor(network: Network) {
     super(network, 'Sui', 'vaa');
-    this.graphql = new SuiGraphQLClient({ network: this.network, url: SUI_GRAPHQL_URLS[this.network] });
-    this.client = new SuiGrpcClient({ network: this.network, baseUrl: SUI_GRPC_URLS[this.network] });
+    this.graphql = new SuiGraphQLClient({
+      network: this.network,
+      url: SUI_GRAPHQL_URLS[this.network],
+    });
+    this.client = new SuiGrpcClient({
+      network: this.network,
+      baseUrl: SUI_GRPC_URLS[this.network],
+    });
   }
 
   // TODO: this might break using numbers, the whole service needs a refactor to use BigInt
   async getFinalizedBlockNumber(): Promise<number> {
     const { response: info } = await this.client.ledgerService.getServiceInfo({});
     if (!info.checkpointHeight) {
-      throw new Error('Failed to retrieve last checkpoint height')
+      throw new Error('Failed to retrieve last checkpoint height');
     }
     return Number(info.checkpointHeight);
   }
@@ -94,7 +103,7 @@ export class SuiWatcher extends Watcher {
         return { vaasByBlock };
       }
 
-      this.logger.debug(`fetched ${events.length} publish message events`)
+      this.logger.debug(`fetched ${events.length} publish message events`);
 
       cursor = pagination.endCursor;
       hasNextPage = pagination.hasNextPage;
@@ -118,7 +127,12 @@ export class SuiWatcher extends Watcher {
 
         const msg = event.contents.json;
         const timestamp = new Date(Number(msg.timestamp) * 1000).toISOString();
-        const vaaKey = makeVaaKey(event.transaction.digest, 'Sui', msg.sender.slice(2), msg.sequence);
+        const vaaKey = makeVaaKey(
+          event.transaction.digest,
+          'Sui',
+          msg.sender.slice(2),
+          msg.sequence
+        );
         const blockKey = makeBlockKey(checkpoint, timestamp);
         vaasByBlock[blockKey] = [...(vaasByBlock[blockKey] || []), vaaKey];
       }
@@ -127,25 +141,27 @@ export class SuiWatcher extends Watcher {
   }
 
   private async fetchCheckpoint(fromCheckpoint: number): Promise<Checkpoint> {
-    const { response } = await this.client.ledgerService.getCheckpoint(
-      {
-        checkpointId: { oneofKind: 'sequenceNumber', sequenceNumber: BigInt(fromCheckpoint) },
-        readMask: {
-          paths: ['summary']
-        }
-      }
-    );
+    const { response } = await this.client.ledgerService.getCheckpoint({
+      checkpointId: { oneofKind: 'sequenceNumber', sequenceNumber: BigInt(fromCheckpoint) },
+      readMask: {
+        paths: ['summary'],
+      },
+    });
     if (!response.checkpoint) {
-      throw new Error(`Failed to fetch checkpoint: ${fromCheckpoint}`)
+      throw new Error(`Failed to fetch checkpoint: ${fromCheckpoint}`);
     }
     return response.checkpoint;
   }
 
-  private async fetchEvents(from: number, to: number, cursor?: string): Promise<FetchEventsResponse<PublishMessageEvent>> {
+  private async fetchEvents(
+    from: number,
+    to: number,
+    cursor?: string
+  ): Promise<FetchEventsResponse<PublishMessageEvent>> {
     const { data, errors } = await this.graphql.query<GraphQLFetchEventsResponse>({
-        query: this.graphqlEventsQuery(from, to, cursor),
-        variables: {}
-      });
+      query: this.graphqlEventsQuery(from, to, cursor),
+      variables: {},
+    });
 
     if (errors && errors.length > 0) {
       throw new Error(`Failed to fetch events: ${errors.join('\n')}`);
@@ -153,7 +169,7 @@ export class SuiWatcher extends Watcher {
 
     return {
       events: data!.events.nodes,
-      pagination: data!.events.pageInfo
+      pagination: data!.events.pageInfo,
     };
   }
 
@@ -161,21 +177,20 @@ export class SuiWatcher extends Watcher {
     const { response } = await this.client.ledgerService.batchGetTransactions({
       digests,
       readMask: {
-        paths: ['digest', 'checkpoint']
-      }
+        paths: ['digest', 'checkpoint'],
+      },
     });
 
     // add the manual cast since typescript won't narrow the type down after the filter
-    const results =
-      response.transactions
-        .map(r => r.result)
-        .filter(r => r.oneofKind === 'transaction') as SuccessfulGetTransactionResult[];
+    const results = response.transactions
+      .map((r) => r.result)
+      .filter((r) => r.oneofKind === 'transaction') as SuccessfulGetTransactionResult[];
 
     if (results.length !== digests.length) {
       throw new Error(`Expected to get ${digests.length} but got ${results.length}`);
     }
 
-    return results.map(r => r.transaction);
+    return results.map((r) => r.transaction);
   }
 
   private graphqlEventsQuery(from: number, to: number, cursor?: string): string {

--- a/watcher/src/watchers/SuiWatcher.ts
+++ b/watcher/src/watchers/SuiWatcher.ts
@@ -1,9 +1,14 @@
-import { SuiClient } from '@mysten/sui/client';
-import { RPCS_BY_CHAIN } from '../consts';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { RPCS_BY_CHAIN, SUI_GRAPHQL_URLS, SUI_GRPC_URLS } from '../consts';
 import { VaasByBlock } from '../databases/types';
 import { Watcher } from './Watcher';
 import { makeBlockKey, makeVaaKey } from '../databases/utils';
 import { Network } from '@wormhole-foundation/sdk-base';
+// no public re-exports available for these proto-generated types
+import { ExecutedTransaction } from '@mysten/sui/dist/cjs/grpc/proto/sui/rpc/v2/executed_transaction';
+import { GetTransactionResult } from '@mysten/sui/dist/cjs/grpc/proto/sui/rpc/v2/ledger_service';
+import { Checkpoint } from '@mysten/sui/dist/cjs/grpc/proto/sui/rpc/v2/checkpoint';
 
 const SUI_EVENT_HANDLE = `0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage`;
 
@@ -16,18 +21,48 @@ type PublishMessageEvent = {
   timestamp: string;
 };
 
+type EventData<T = any> = {
+  transaction: {
+    digest: string;
+  };
+  contents: {
+    json: T;
+  };
+};
+type Pagination = {
+  hasNextPage: boolean;
+  endCursor: string;
+};
+type GraphQLFetchEventsResponse = {
+  events: {
+    nodes: EventData[];
+    pageInfo: Pagination;
+  };
+};
+type FetchEventsResponse<T = any> = {
+  events: EventData<T>[];
+  pagination: Pagination;
+};
+type SuccessfulGetTransactionResult = Extract<GetTransactionResult['result'], { oneofKind: 'transaction' }>;
+
 export class SuiWatcher extends Watcher {
-  client: SuiClient;
-  maximumBatchSize: number = 100000; // arbitrarily large as this pages back by events
+  graphql: SuiGraphQLClient;
+  client: SuiGrpcClient;
+  maximumBatchSize: number = 100000; // arbitrarily large as this pages by events
 
   constructor(network: Network) {
     super(network, 'Sui', 'vaa');
-    this.client = new SuiClient({ url: RPCS_BY_CHAIN[this.network][this.chain]! });
+    this.graphql = new SuiGraphQLClient({ network: this.network, url: SUI_GRAPHQL_URLS[this.network] });
+    this.client = new SuiGrpcClient({ network: this.network, baseUrl: SUI_GRPC_URLS[this.network] });
   }
 
   // TODO: this might break using numbers, the whole service needs a refactor to use BigInt
   async getFinalizedBlockNumber(): Promise<number> {
-    return Number(await this.client.getLatestCheckpointSequenceNumber());
+    const { response: info } = await this.client.ledgerService.getServiceInfo({});
+    if (!info.checkpointHeight) {
+      throw new Error('Failed to retrieve last checkpoint height')
+    }
+    return Number(info.checkpointHeight);
   }
 
   // TODO: this might break using numbers, the whole service needs a refactor to use BigInt
@@ -40,54 +75,134 @@ export class SuiWatcher extends Watcher {
 
     {
       // reserve empty slot for initial block so query is cataloged
+      const checkpoint = await this.fetchCheckpoint(fromCheckpoint);
       const fromCheckpointTimestamp = new Date(
-        Number((await this.client.getCheckpoint({ id: fromCheckpoint.toString() })).timestampMs)
+        // TODO: check if nano/ms/s units
+        Number(checkpoint.summary?.timestamp?.seconds) * 1000
       ).toISOString();
       const fromBlockKey = makeBlockKey(fromCheckpoint.toString(), fromCheckpointTimestamp);
       vaasByBlock[fromBlockKey] = [];
     }
 
-    let lastCheckpoint: null | number = null;
-    let cursor: any = undefined;
+    let cursor: string | undefined = undefined;
     let hasNextPage = false;
     do {
-      const response = await this.client.queryEvents({
-        query: { MoveEventType: SUI_EVENT_HANDLE },
-        cursor,
-        order: 'descending',
-      });
-      const digest = response.data.length
-        ? response.data[response.data.length - 1].id.txDigest
-        : null;
-      lastCheckpoint = digest
-        ? Number((await this.client.getTransactionBlock({ digest })).checkpoint!)
-        : null;
-      cursor = response.nextCursor;
-      hasNextPage = response.hasNextPage;
-      const digestArrayWithDups = response.data.map((e) => e.id.txDigest);
+      const { events, pagination } = await this.fetchEvents(fromCheckpoint, toCheckpoint, cursor);
+
+      // no events, early return
+      if (!events.length) {
+        return { vaasByBlock };
+      }
+
+      this.logger.debug(`fetched ${events.length} publish message events`)
+
+      cursor = pagination.endCursor;
+      hasNextPage = pagination.hasNextPage;
+
+      const digestArrayWithDups = events.map((e) => e.transaction.digest);
       const digestArray = Array.from(new Set(digestArrayWithDups));
-      const txBlocks = await this.client.multiGetTransactionBlocks({
-        digests: digestArray,
-      });
-      const checkpointByTxDigest = txBlocks.reduce<Record<string, string | undefined>>(
+
+      const txs = await this.fetchTransactions(digestArray);
+
+      const checkpointByTxDigest = txs.reduce<Record<string, string | undefined>>(
         (value, { digest, checkpoint }) => {
-          value[digest] = checkpoint || undefined;
+          value[digest!] = checkpoint?.toString() || undefined;
           return value;
         },
         {}
       );
-      for (const event of response.data) {
-        const checkpoint = checkpointByTxDigest[event.id.txDigest];
+
+      for (const event of events) {
+        const checkpoint = checkpointByTxDigest[event.transaction.digest];
         if (!checkpoint) continue;
-        const checkpointNum = Number(checkpoint);
-        if (checkpointNum < fromCheckpoint || checkpointNum > toCheckpoint) continue;
-        const msg = event.parsedJson as PublishMessageEvent;
+
+        const msg = event.contents.json;
         const timestamp = new Date(Number(msg.timestamp) * 1000).toISOString();
-        const vaaKey = makeVaaKey(event.id.txDigest, 'Sui', msg.sender.slice(2), msg.sequence);
+        const vaaKey = makeVaaKey(event.transaction.digest, 'Sui', msg.sender.slice(2), msg.sequence);
         const blockKey = makeBlockKey(checkpoint, timestamp);
         vaasByBlock[blockKey] = [...(vaasByBlock[blockKey] || []), vaaKey];
       }
-    } while (hasNextPage && lastCheckpoint && fromCheckpoint < lastCheckpoint);
+    } while (hasNextPage);
     return { vaasByBlock };
+  }
+
+  private async fetchCheckpoint(fromCheckpoint: number): Promise<Checkpoint> {
+    const { response } = await this.client.ledgerService.getCheckpoint(
+      {
+        checkpointId: { oneofKind: 'sequenceNumber', sequenceNumber: BigInt(fromCheckpoint) },
+        readMask: {
+          paths: ['summary']
+        }
+      }
+    );
+    if (!response.checkpoint) {
+      throw new Error(`Failed to fetch checkpoint: ${fromCheckpoint}`)
+    }
+    return response.checkpoint;
+  }
+
+  private async fetchEvents(from: number, to: number, cursor?: string): Promise<FetchEventsResponse<PublishMessageEvent>> {
+    const { data, errors } = await this.graphql.query<GraphQLFetchEventsResponse>({
+        query: this.graphqlEventsQuery(from, to, cursor),
+        variables: {}
+      });
+
+    if (errors && errors.length > 0) {
+      throw new Error(`Failed to fetch events: ${errors.join('\n')}`);
+    }
+
+    return {
+      events: data!.events.nodes,
+      pagination: data!.events.pageInfo
+    };
+  }
+
+  private async fetchTransactions(digests: string[]): Promise<ExecutedTransaction[]> {
+    const { response } = await this.client.ledgerService.batchGetTransactions({
+      digests,
+      readMask: {
+        paths: ['digest', 'checkpoint']
+      }
+    });
+
+    // add the manual cast since typescript won't narrow the type down after the filter
+    const results =
+      response.transactions
+        .map(r => r.result)
+        .filter(r => r.oneofKind === 'transaction') as SuccessfulGetTransactionResult[];
+
+    if (results.length !== digests.length) {
+      throw new Error(`Expected to get ${digests.length} but got ${results.length}`);
+    }
+
+    return results.map(r => r.transaction);
+  }
+
+  private graphqlEventsQuery(from: number, to: number, cursor?: string): string {
+    // order is ascending from older to newest
+    // checkpoint range is non-inclusive
+    return `{
+      events(
+        filter: {
+          type: "${SUI_EVENT_HANDLE}",
+          afterCheckpoint: ${from - 1},
+          beforeCheckpoint: ${to + 1}
+        }
+        ${cursor ? `after: "${cursor}"` : ''}
+      ) {
+        nodes {
+          transaction {
+            digest
+          }
+          contents {
+            json
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }`;
   }
 }

--- a/watcher/src/watchers/SuiWatcher.ts
+++ b/watcher/src/watchers/SuiWatcher.ts
@@ -86,7 +86,6 @@ export class SuiWatcher extends Watcher {
       // reserve empty slot for initial block so query is cataloged
       const checkpoint = await this.fetchCheckpoint(fromCheckpoint);
       const fromCheckpointTimestamp = new Date(
-        // TODO: check if nano/ms/s units
         Number(checkpoint.summary?.timestamp?.seconds) * 1000
       ).toISOString();
       const fromBlockKey = makeBlockKey(fromCheckpoint.toString(), fromCheckpointTimestamp);

--- a/watcher/src/watchers/__tests__/SuiWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/SuiWatcher.test.ts
@@ -1,34 +1,101 @@
-import { expect, jest, test } from '@jest/globals';
+import { beforeAll, expect, jest, test } from '@jest/globals';
 import { INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN } from '@wormhole-foundation/wormhole-monitor-common/dist/consts';
 import { SuiWatcher } from '../SuiWatcher';
 
 jest.setTimeout(60000);
 
-const INITAL_SEQUENCE_NUMBER = Number(
+const INITIAL_CHECKPOINT = Number(
   INITIAL_DEPLOYMENT_BLOCK_BY_NETWORK_AND_CHAIN['Mainnet'].Sui ?? 1581000
 );
 
-test('getFinalizedSequenceNumber', async () => {
-  const watcher = new SuiWatcher('Mainnet');
-  const blockNumber = await watcher.getFinalizedBlockNumber();
-  console.log('Received blockNumber:', blockNumber);
-  expect(blockNumber).toBeGreaterThan(INITAL_SEQUENCE_NUMBER);
+// Public Sui fullnodes prune historical checkpoint data; tests use a dynamically-computed
+// recent range so they remain valid as the chain grows. A small head buffer avoids any
+// finality/indexer-lag edge cases.
+const HEAD_BUFFER = 100;
+const RANGE_WIDTH = 5000; // ~25 minutes of Sui checkpoints; wide enough to virtually guarantee Wormhole activity
+
+let watcher: SuiWatcher;
+let latestCheckpoint: number;
+let recentFrom: number;
+let recentTo: number;
+
+beforeAll(async () => {
+  watcher = new SuiWatcher('Mainnet');
+  latestCheckpoint = await watcher.getFinalizedBlockNumber();
+  recentTo = latestCheckpoint - HEAD_BUFFER;
+  recentFrom = recentTo - RANGE_WIDTH;
 });
 
-// This test will fail as time goes on because getMessagesForBlocks() grabs the latest and
-// works backwards.  This will cause a 429 until we clear that up.
-test.skip('getMessagesForBlocks', async () => {
-  const watcher = new SuiWatcher('Mainnet');
-  const { vaasByBlock: messages } = await watcher.getMessagesForBlocks(1581997, 1581997);
-  console.log(messages);
-  const entries = Object.entries(messages);
-  expect(entries.length).toEqual(46);
-  expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(1);
-  expect(entries.filter(([block, vaas]) => vaas.length === 1).length).toEqual(40);
-  expect(entries.filter(([block, vaas]) => vaas.length === 2).length).toEqual(5);
-  expect(messages['1584976/2023-05-03T17:15:00.000Z']).toBeDefined();
-  expect(messages['1584976/2023-05-03T17:15:00.000Z'].length).toEqual(1);
-  expect(messages['1584976/2023-05-03T17:15:00.000Z'][0]).toEqual(
-    'HydDe4yNBBu98ak46fPdw7qCZ4x7h8DsYdMfeWEBf5ge:21/ccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5/187'
-  );
+test('getFinalizedBlockNumber returns a checkpoint past the deployment block', () => {
+  console.log('Received blockNumber:', latestCheckpoint);
+  expect(latestCheckpoint).toBeGreaterThan(INITIAL_CHECKPOINT);
+});
+
+test('getMessagesForBlocks reserves a slot for fromCheckpoint', async () => {
+  // single-checkpoint range: regardless of whether events exist, the initial slot must be present
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(recentFrom, recentFrom);
+
+  const initialSlot = Object.keys(vaasByBlock).find((k) => k.startsWith(`${recentFrom}/`));
+  expect(initialSlot).toBeDefined();
+  expect(vaasByBlock[initialSlot!]).toBeDefined();
+});
+
+// guards against the gRPC `summary.timestamp` field being misinterpreted (seconds vs ms vs Timestamp proto)
+test('initial slot timestamp parses as a real, recent date', async () => {
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(recentFrom, recentFrom);
+
+  const initialSlot = Object.keys(vaasByBlock).find((k) => k.startsWith(`${recentFrom}/`));
+  expect(initialSlot).toBeDefined();
+
+  const isoTimestamp = initialSlot!.split('/').slice(1).join('/');
+  const parsed = new Date(isoTimestamp);
+  expect(Number.isNaN(parsed.getTime())).toBe(false);
+
+  // a unit error (e.g. seconds interpreted as ms) would put the date in 1970 or far in the future
+  const ageMs = Date.now() - parsed.getTime();
+  expect(ageMs).toBeGreaterThan(0);
+  expect(ageMs).toBeLessThan(24 * 60 * 60 * 1000);
+});
+
+test('getMessagesForBlocks over a multi-checkpoint range stays within the requested bounds', async () => {
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(recentFrom, recentTo);
+
+  const blockKeys = Object.keys(vaasByBlock);
+  expect(blockKeys.length).toBeGreaterThan(0);
+
+  // verifies the off-by-one workaround (afterCheckpoint: from-1, beforeCheckpoint: to+1) doesn't leak events outside the range
+  for (const blockKey of blockKeys) {
+    const checkpoint = Number(blockKey.split('/')[0]);
+    expect(checkpoint).toBeGreaterThanOrEqual(recentFrom);
+    expect(checkpoint).toBeLessThanOrEqual(recentTo);
+  }
+});
+
+test('event block keys have timestamps consistent with their checkpoints', async () => {
+  // Catches a regression where event timestamps (msg.timestamp, in seconds) get mixed up with
+  // checkpoint timestamps (summary.timestamp). Both should land in the recent window.
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(recentFrom, recentTo);
+
+  for (const blockKey of Object.keys(vaasByBlock)) {
+    if (vaasByBlock[blockKey].length === 0) continue; // skip empty slot for fromCheckpoint
+    const iso = blockKey.split('/').slice(1).join('/');
+    const t = new Date(iso);
+    expect(Number.isNaN(t.getTime())).toBe(false);
+    const ageMs = Date.now() - t.getTime();
+    expect(ageMs).toBeGreaterThan(0);
+    expect(ageMs).toBeLessThan(24 * 60 * 60 * 1000);
+  }
+});
+
+test('VAA keys conform to <digest>:21/<emitter>/<sequence>', async () => {
+  const { vaasByBlock } = await watcher.getMessagesForBlocks(recentFrom, recentTo);
+
+  const vaaKeys = Object.values(vaasByBlock).flat();
+  // a 5000-checkpoint window on Sui Mainnet (~25 min) should always contain Wormhole activity
+  expect(vaaKeys.length).toBeGreaterThan(0);
+
+  for (const vaa of vaaKeys) {
+    // chainId is 21 for Sui; emitter is hex without 0x; sequence is numeric
+    expect(vaa).toMatch(/^[A-Za-z0-9]+:21\/[0-9a-f]+\/\d+$/);
+  }
 });

--- a/watcher/tsconfig.json
+++ b/watcher/tsconfig.json
@@ -3,7 +3,6 @@
   "references": [{ "path": "../common" }],
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "node",
     "outDir": "dist",
     "baseUrl": "./",
     "paths": {}


### PR DESCRIPTION
Sui JSON RPC is getting deprecated by the end of July, so replace the Sui Watcher json rpc client usage with grpc and graphql. Use default sui providers unless `SUI_GRAPHQL_URL` or `SUI_GRPC_URL` are present on the env vars.