### PR TITLE
fix(dashboard): show all accountant pending transfers

### DIFF
--- a/dashboard/src/components/Accountant.tsx
+++ b/dashboard/src/components/Accountant.tsx
@@ -42,7 +42,7 @@ import { useSettingsContext } from '../contexts/SettingsContext';
 import { CloudGovernorInfo } from '../hooks/useCloudGovernorInfo';
 import useGetAccountantAccounts, { Account } from '../hooks/useGetAccountantAccounts';
 import useGetAccountantPendingTransfers, {
-  PendingTransfer,
+  PendingTransferRow,
 } from '../hooks/useGetAccountantPendingTransfers';
 import { TokenDataByChainAddress, TokenDataEntry } from '../hooks/useTokenData';
 import { CHAIN_ICON_MAP, WORMCHAIN_URL } from '../utils/consts';
@@ -71,7 +71,7 @@ const NTT_ACCOUNTANT_TOKEN_ADDRESS_OVERRIDE: {
   },
 };
 
-type PendingTransferForAcct = PendingTransfer & { isEnqueuedInGov: boolean };
+type PendingTransferForAcct = PendingTransferRow & { isEnqueuedInGov: boolean };
 type AccountWithTokenData = Account & {
   tokenData: TokenDataEntry;
   tvlTvm: number;
@@ -161,27 +161,30 @@ const guardianSigningColumns = [
 const pendingTransferColumnHelper = createColumnHelper<PendingTransferForAcct>();
 
 const pendingTransferColumns = [
-  pendingTransferColumnHelper.accessor('key.emitter_chain', {
+  pendingTransferColumnHelper.accessor('emitter_chain', {
     header: () => 'Chain',
     cell: (info) => `${chainIdToName(info.getValue())} (${info.getValue()})`,
     sortingFn: `text`,
   }),
-  pendingTransferColumnHelper.accessor('key.emitter_address', {
+  pendingTransferColumnHelper.accessor('emitter_address', {
     header: () => 'Emitter',
   }),
-  pendingTransferColumnHelper.accessor('key.sequence', {
+  pendingTransferColumnHelper.accessor('sequence', {
     header: () => 'Sequence',
   }),
-  pendingTransferColumnHelper.accessor('data.0.tx_hash', {
+  pendingTransferColumnHelper.accessor('tx_hash', {
     header: () => 'Tx',
     cell: (info) => (
       <ExplorerTxHash
-        chainId={info.row.original.key.emitter_chain}
+        chainId={info.row.original.emitter_chain}
         rawTxHash={'0x' + Buffer.from(info.getValue(), 'base64').toString('hex')}
       />
     ),
   }),
-  pendingTransferColumnHelper.accessor('data.0.signatures', {
+  pendingTransferColumnHelper.accessor('guardian_set_index', {
+    header: () => 'Guardian Set',
+  }),
+  pendingTransferColumnHelper.accessor('signatures', {
     header: () => 'Signatures',
     cell: (info) => (
       <Tooltip
@@ -448,16 +451,16 @@ function Accountant({
   const pendingTransfersForAcct: PendingTransferForAcct[] = useMemo(
     () =>
       pendingTransferInfo
-        .filter((pt) => showUnknownChains || isChainId(pt.key.emitter_chain))
+        .filter((pt) => showUnknownChains || isChainId(pt.emitter_chain))
         .map((transfer) => ({
           ...transfer,
           isEnqueuedInGov:
             governorInfoIsDefined &&
             !!governorInfo.enqueuedVAAs.find(
               (vaa) =>
-                vaa.emitterChain === transfer.key.emitter_chain &&
-                vaa.emitterAddress === transfer.key.emitter_address &&
-                vaa.sequence === transfer.key.sequence.toString()
+                vaa.emitterChain === transfer.emitter_chain &&
+                vaa.emitterAddress === transfer.emitter_address &&
+                vaa.sequence === transfer.sequence.toString()
             ),
         })),
     [pendingTransferInfo, governorInfoIsDefined, governorInfo?.enqueuedVAAs, showUnknownChains]
@@ -470,7 +473,7 @@ function Accountant({
       outOf: pendingTransferInfo.length,
     }));
     for (const transfer of pendingTransferInfo) {
-      const bitString = getSignatureBits(transfer.data[0].signatures);
+      const bitString = getSignatureBits(transfer.signatures);
       for (let idx = 0; idx < bitString.length; idx++) {
         if (bitString[idx] === '1') {
           stats[bitString.length - 1 - idx].numSigned += 1;
@@ -549,7 +552,7 @@ function Accountant({
     state: {
       sorting: pendingTransferSorting,
     },
-    getRowId: (key) => JSON.stringify(key),
+    getRowId: (row) => JSON.stringify(row),
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -595,9 +598,9 @@ function Accountant({
   const pendingByChain = useMemo(
     () =>
       pendingTransferInfo
-        .filter((pt) => showUnknownChains || isChainId(pt.key.emitter_chain))
+        .filter((pt) => showUnknownChains || isChainId(pt.emitter_chain))
         .reduce((obj, cur) => {
-          obj[cur.key.emitter_chain] = (obj[cur.key.emitter_chain] || 0) + 1;
+          obj[cur.emitter_chain] = (obj[cur.emitter_chain] || 0) + 1;
           return obj;
         }, {} as { [chainId: number]: number }),
     [pendingTransferInfo, showUnknownChains]

--- a/dashboard/src/hooks/useGetAccountantPendingTransfers.ts
+++ b/dashboard/src/hooks/useGetAccountantPendingTransfers.ts
@@ -12,21 +12,26 @@ export type PendingTransferKey = {
   sequence: number;
 };
 
-export type PendingTransfer = {
-  key: PendingTransferKey;
-  data: [
-    {
-      digest: string;
-      tx_hash: string;
-      signatures: string;
-      guardian_set_index: number;
-      emitter_chain: number;
-    }
-  ];
+export type PendingTransferData = {
+  digest: string;
+  tx_hash: string;
+  signatures: string;
+  guardian_set_index: number;
+  emitter_chain: number;
 };
 
+export type PendingTransfer = {
+  key: PendingTransferKey;
+  data: PendingTransferData[];
+};
+
+// A single flattened row of the pending transfers table: one entry from a
+// pending transfer's `data` array combined with its key. The key is not unique
+// across rows since a single key can have multiple pending data entries.
+export type PendingTransferRow = PendingTransferKey & PendingTransferData;
+
 export type AccountantPendingTransfersResult = {
-  pendingTransfers: PendingTransfer[];
+  pendingTransfers: PendingTransferRow[];
   receivedAt: string | null;
 };
 
@@ -61,8 +66,13 @@ const useGetAccountantPendingTransfers = (
             start_after =
               response.pending.length && response.pending[response.pending.length - 1].key;
           } while (response.pending.length === PAGE_LIMIT);
+          // Flatten each pending transfer into one row per data entry so the
+          // table shows a line for every entry rather than just the first.
+          const rows: PendingTransferRow[] = pending.flatMap((pt) =>
+            pt.data.map((d) => ({ ...pt.key, ...d }))
+          );
           if (!cancelled) {
-            setResult({ pendingTransfers: pending, receivedAt: new Date().toISOString() });
+            setResult({ pendingTransfers: rows, receivedAt: new Date().toISOString() });
           }
         } catch (error) {
           if (!cancelled) {


### PR DESCRIPTION
previously, the accountant section was only displaying the first pending transfer for each key returned. however, the key is chain/emitter/seq but each guardian set index or transaction hash receives its own entry in a vec under that key. this PR updates the display to show each unique entry as they are actually tracked.

I did not add a feature to only show the most recent guardian set, as there could also be a tx hash conflict in the future and this is the most transparent display for debugging / analysis purposes.