### PR TITLE
feat(dashboard): hide stale pending txs by default

### DIFF
--- a/common/src/guardianSet.ts
+++ b/common/src/guardianSet.ts
@@ -83,3 +83,6 @@ export const GUARDIAN_SET_7 = [
 
 /** Always points to the active guardian set. Update GUARDIAN_SET_N above and bump this alias. */
 export const GUARDIAN_SET = GUARDIAN_SET_7;
+
+/** The index of the active guardian set. */
+export const GUARDIAN_SET_INDEX = 7;

--- a/dashboard/src/components/Accountant.tsx
+++ b/dashboard/src/components/Accountant.tsx
@@ -31,6 +31,7 @@ import { isChainId } from '@wormhole-foundation/sdk-base';
 import {
   ACCOUNTANT_CONTRACT_ADDRESS,
   GUARDIAN_SET,
+  GUARDIAN_SET_INDEX,
   chainIdToName,
 } from '@wormhole-foundation/wormhole-monitor-common';
 import { queryContractSmart } from '@wormhole-foundation/wormhole-monitor-common/src/queryContractSmart';
@@ -429,7 +430,7 @@ function Accountant({
   isNTT?: boolean;
 }) {
   const {
-    settings: { showUnknownChains },
+    settings: { showUnknownChains, showAllAccountantPendingTransfers },
   } = useSettingsContext();
   const [open, setOpen] = useState(false);
   const handleOpen = useCallback((event: any) => {
@@ -465,6 +466,21 @@ function Accountant({
         })),
     [pendingTransferInfo, governorInfoIsDefined, governorInfo?.enqueuedVAAs, showUnknownChains]
   );
+
+  // Unless the user opts in to showing all, hide stale pending transfers whose
+  // guardian set index is older than the current guardian set. Use >= so a
+  // transfer is only hidden when it's strictly older, in case the constant lags
+  // behind the transfers.
+  const hideStalePendingTransfers = !showAllAccountantPendingTransfers;
+  const visiblePendingTransfers: PendingTransferForAcct[] = useMemo(
+    () =>
+      hideStalePendingTransfers
+        ? pendingTransfersForAcct.filter((pt) => pt.guardian_set_index >= GUARDIAN_SET_INDEX)
+        : pendingTransfersForAcct,
+    [pendingTransfersForAcct, hideStalePendingTransfers]
+  );
+  const hiddenPendingTransferCount =
+    pendingTransfersForAcct.length - visiblePendingTransfers.length;
 
   const guardianSigningStats: GuardianSigningStat[] = useMemo(() => {
     const stats: GuardianSigningStat[] = GUARDIAN_SET.map((g) => ({
@@ -548,7 +564,7 @@ function Accountant({
   const [pendingTransferSorting, setPendingTransferSorting] = useState<SortingState>([]);
   const pendingTransfer = useReactTable({
     columns: pendingTransferColumns,
-    data: pendingTransfersForAcct,
+    data: visiblePendingTransfers,
     state: {
       sorting: pendingTransferSorting,
     },
@@ -597,13 +613,11 @@ function Accountant({
   });
   const pendingByChain = useMemo(
     () =>
-      pendingTransferInfo
-        .filter((pt) => showUnknownChains || isChainId(pt.emitter_chain))
-        .reduce((obj, cur) => {
-          obj[cur.emitter_chain] = (obj[cur.emitter_chain] || 0) + 1;
-          return obj;
-        }, {} as { [chainId: number]: number }),
-    [pendingTransferInfo, showUnknownChains]
+      visiblePendingTransfers.reduce((obj, cur) => {
+        obj[cur.emitter_chain] = (obj[cur.emitter_chain] || 0) + 1;
+        return obj;
+      }, {} as { [chainId: number]: number }),
+    [visiblePendingTransfers]
   );
   return (
     <>
@@ -685,6 +699,7 @@ function Accountant({
               table={pendingTransfer}
               paginated={!!pendingTransferInfo.length}
               showRowCount={!!pendingTransferInfo.length}
+              hiddenRowCount={hiddenPendingTransferCount}
             />
             {pendingTransferInfo.length === 0 ? (
               <Typography variant="body2" sx={{ py: 1, textAlign: 'center' }}>

--- a/dashboard/src/components/Settings.tsx
+++ b/dashboard/src/components/Settings.tsx
@@ -29,6 +29,7 @@ function SettingsContent() {
     updateShowUnknownChains,
     updateShowAllMisses,
     updateShowMonitorDetails,
+    updateShowAllAccountantPendingTransfers,
   } = useSettingsContext();
   const handleThemeChange = useCallback(
     (event: any, newTheme: Theme) => {
@@ -71,6 +72,12 @@ function SettingsContent() {
       updateShowMonitorDetails(event.target.checked);
     },
     [updateShowMonitorDetails]
+  );
+  const handleShowAllAccountantPendingTransfers = useCallback(
+    (event: any) => {
+      updateShowAllAccountantPendingTransfers(event.target.checked);
+    },
+    [updateShowAllAccountantPendingTransfers]
   );
   return (
     <>
@@ -139,6 +146,17 @@ function SettingsContent() {
             <Checkbox checked={!!settings.showMonitorDetails} onChange={handleShowMonitorDetails} />
           }
           label="Show monitor details"
+        />
+      </Box>
+      <Box m={2}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={!!settings.showAllAccountantPendingTransfers}
+              onChange={handleShowAllAccountantPendingTransfers}
+            />
+          }
+          label="Show stale accountant pending transfers"
         />
       </Box>
     </>

--- a/dashboard/src/components/Table.tsx
+++ b/dashboard/src/components/Table.tsx
@@ -32,6 +32,7 @@ function Table<T>({
   paginated = false,
   showRowCount = false,
   showColumnFilters = false,
+  hiddenRowCount = 0,
   conditionalRowStyle,
 }: {
   table: TanTable<T>;
@@ -39,6 +40,7 @@ function Table<T>({
   paginated?: boolean;
   showRowCount?: boolean;
   showColumnFilters?: boolean;
+  hiddenRowCount?: number;
   conditionalRowStyle?: (a: T) => SxProps<Theme> | undefined;
 }) {
   const theme = useTheme();
@@ -133,7 +135,10 @@ function Table<T>({
             <TableRow>
               <TableCell>
                 <Box display="flex" alignItems="center">
-                  <Box>{table.getCoreRowModel().rows.length} Rows</Box>
+                  <Box>
+                    {table.getCoreRowModel().rows.length} Rows
+                    {hiddenRowCount > 0 ? ` (${hiddenRowCount} hidden)` : ''}
+                  </Box>
                   <Box flexGrow={1} />
                   {paginated ? (
                     <>

--- a/dashboard/src/contexts/SettingsContext.tsx
+++ b/dashboard/src/contexts/SettingsContext.tsx
@@ -12,6 +12,7 @@ type Settings = {
   showUnknownChains?: boolean;
   showAllMisses?: boolean;
   showMonitorDetails?: boolean;
+  showAllAccountantPendingTransfers?: boolean;
 };
 
 type SettingsContextValue = {
@@ -23,6 +24,7 @@ type SettingsContextValue = {
   updateShowUnknownChains(value: boolean): void;
   updateShowAllMisses(value: boolean): void;
   updateShowMonitorDetails(value: boolean): void;
+  updateShowAllAccountantPendingTransfers(value: boolean): void;
 };
 
 const isTheme = (arg: any): arg is Theme => {
@@ -61,6 +63,7 @@ const SettingsContext = React.createContext<SettingsContextValue>({
   updateShowUnknownChains: (value: boolean) => {},
   updateShowAllMisses: (value: boolean) => {},
   updateShowMonitorDetails: (value: boolean) => {},
+  updateShowAllAccountantPendingTransfers: (value: boolean) => {},
 });
 
 export const SettingsContextProvider = ({ children }: { children: ReactNode }) => {
@@ -86,6 +89,9 @@ export const SettingsContextProvider = ({ children }: { children: ReactNode }) =
   const updateShowMonitorDetails = useCallback((value: boolean) => {
     setSettings((settings) => ({ ...settings, showMonitorDetails: value }));
   }, []);
+  const updateShowAllAccountantPendingTransfers = useCallback((value: boolean) => {
+    setSettings((settings) => ({ ...settings, showAllAccountantPendingTransfers: value }));
+  }, []);
   // sync settings to state
   useEffect(() => {
     saveSettings(settings);
@@ -100,6 +106,7 @@ export const SettingsContextProvider = ({ children }: { children: ReactNode }) =
       updateShowUnknownChains,
       updateShowAllMisses,
       updateShowMonitorDetails,
+      updateShowAllAccountantPendingTransfers,
     }),
     [
       settings,
@@ -110,6 +117,7 @@ export const SettingsContextProvider = ({ children }: { children: ReactNode }) =
       updateShowUnknownChains,
       updateShowAllMisses,
       updateShowMonitorDetails,
+      updateShowAllAccountantPendingTransfers,
     ]
   );
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;

--- a/scripts/generate-guardian-set.ts
+++ b/scripts/generate-guardian-set.ts
@@ -81,6 +81,9 @@ ${entries},
 
 /** Always points to the active guardian set. Update GUARDIAN_SET_N above and bump this alias. */
 export const GUARDIAN_SET = ${SET_NAME};
+
+/** The index of the active guardian set. */
+export const GUARDIAN_SET_INDEX = ${VERSION};
 `;
 }
 


### PR DESCRIPTION
This PR hides accountant pending transactions that are not from the current guardian set. All pending transactions can be shown via a setting, akin to the other settings.